### PR TITLE
ci: address shellcheck findings to allow check to be made required

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 13.3.rel1
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 permissions: {}

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -21,4 +21,6 @@ shell=bash
 #   SC2016 – single-quoted $ expansion: eval statements intentionally use
 #            literal $ to defer variable expansion until eval executes, not at
 #            the point the string is constructed.
-disable=SC2034,SC2268,SC2016
+#   SC2154 - referenced but not assigned.
+#            temporary suppression to allow shellcheck to be made a required check.
+disable=SC2034,SC2268,SC2016,SC2154


### PR DESCRIPTION
Added SC2154 to the list of disabled ShellCheck warnings.

## Checklist

- [x] The PR title follows the Conventional Commits format (see note below)
- [x] Changes are documented where appropriate

---

> [!IMPORTANT]
> **PR title must follow [Conventional Commits](https://www.conventionalcommits.org/) format.**
>
> PRs are squashed into the target branch using the **PR title** as the commit message.
> The PR title must therefore conform to commitlint requirements:
>
> ```
> <type>[(optional scope)][!]: <description>
> ```
>
> Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`, `perf`, `style`, `revert`
>
> Examples: `feat: add ARMv8-M support`, `fix: correct stack calculation`, `docs: update build instructions`
>
> Individual commits **within** the PR do **not** need to follow this format.
