### PR TITLE
fix: replace eval literal-brace patterns with bash indirect expansion…

### DIFF
--- a/build-common.sh
+++ b/build-common.sh
@@ -324,45 +324,6 @@ LIBICONV_URL=https://ftp.gnu.org/pub/gnu/libiconv/$LIBICONV_PACK
 ZLIB_URL=http://www.zlib.net/fossils/$ZLIB_PACK
 PYTHON_WIN_URL=https://www.python.org/ftp/python/$PYTHON_WIN_VER/$PYTHON_WIN_PACK
 
-TAR=tar
-# Set variables according to real environment to make this script can run
-# on Ubuntu and Mac OS X.
-uname_string=$(uname | sed 'y/LINUXDARWIN/linuxdarwin/')
-host_arch=$(uname -m | sed 'y/XI/xi/')
-if [ "$uname_string" == "linux" ] ; then
-    BUILD="$host_arch"-linux-gnu
-    HOST_NATIVE="$host_arch"-linux-gnu
-    READLINK=readlink
-    JOBS=$(grep ^processor /proc/cpuinfo|wc -l)
-    GCC_CONFIG_OPTS_LCPP="--with-host-libstdcxx=-static-libgcc -Wl,-Bstatic,-lstdc++,-Bdynamic -lm"
-    MD5="md5sum -b"
-    PACKAGE_NAME_SUFFIX="${host_arch}-linux"
-    WGET="wget -q"
-elif [ "$uname_string" == "darwin" ] ; then
-    BUILD=x86_64-apple-darwin10
-    HOST_NATIVE=x86_64-apple-darwin10
-    READLINK=greadlink
-    # Disable parallel build for mac as we will randomly run into "Permission denied" issue.
-    #JOBS=`sysctl -n hw.ncpu`
-    JOBS=1
-    GCC_CONFIG_OPTS_LCPP="--with-host-libstdcxx=-static-libgcc -Wl,-lstdc++ -lm"
-    MD5="md5 -r"
-    PACKAGE_NAME_SUFFIX=mac-$(sw_vers -productVersion)
-    #Redefine wget command to curl as MacOS does not have wget by default
-    WGET="curl -OLs"
-    TAR=gtar
-else
-    error "Unsupported build system : $uname_string"
-fi
-
-SRC_PREREQS="GMP MPFR MPC ISL EXPAT LIBICONV ZLIB"
-WIN_PREREQS="PYTHON_WIN"
-
-PREREQS="$SRC_PREREQS"
-if [ "$BUILD" != "x86_64-apple-darwin10" ]; then
-    PREREQS="$SRC_PREREQS $WIN_PREREQS"
-fi
-
 SCRIPT=$(basename $0)
 
 RELEASEDATE=20230728
@@ -375,6 +336,45 @@ RELEASEVER=Rel1
 if [[ "${SCRIPT%%-*}" = "build" || "${SCRIPT#*_*}" = "build" ]]; then
 
     stack_level=0
+
+    TAR=tar
+    # Set variables according to real environment to make this script can run
+    # on Ubuntu and Mac OS X.
+    uname_string=$(uname | sed 'y/LINUXDARWIN/linuxdarwin/')
+    host_arch=$(uname -m | sed 'y/XI/xi/')
+    if [ "$uname_string" == "linux" ] ; then
+        BUILD="$host_arch"-linux-gnu
+        HOST_NATIVE="$host_arch"-linux-gnu
+        READLINK=readlink
+        JOBS=$(grep ^processor /proc/cpuinfo|wc -l)
+        GCC_CONFIG_OPTS_LCPP="--with-host-libstdcxx=-static-libgcc -Wl,-Bstatic,-lstdc++,-Bdynamic -lm"
+        MD5="md5sum -b"
+        PACKAGE_NAME_SUFFIX="${host_arch}-linux"
+        WGET="wget -q"
+    elif [ "$uname_string" == "darwin" ] ; then
+        BUILD=x86_64-apple-darwin10
+        HOST_NATIVE=x86_64-apple-darwin10
+        READLINK=greadlink
+        # Disable parallel build for mac as we will randomly run into "Permission denied" issue.
+        #JOBS=`sysctl -n hw.ncpu`
+        JOBS=1
+        GCC_CONFIG_OPTS_LCPP="--with-host-libstdcxx=-static-libgcc -Wl,-lstdc++ -lm"
+        MD5="md5 -r"
+        PACKAGE_NAME_SUFFIX=mac-$(sw_vers -productVersion)
+        #Redefine wget command to curl as MacOS does not have wget by default
+        WGET="curl -OLs"
+        TAR=gtar
+    else
+        error "Unsupported build system : $uname_string"
+    fi
+
+    SRC_PREREQS="GMP MPFR MPC ISL EXPAT LIBICONV ZLIB"
+    WIN_PREREQS="PYTHON_WIN"
+
+    PREREQS="$SRC_PREREQS"
+    if [ "$BUILD" != "x86_64-apple-darwin10" ]; then
+        PREREQS="$SRC_PREREQS $WIN_PREREQS"
+    fi
 
     LICENSE_FILE=license.txt
     GCC_VER=$(cat $SRCDIR/$GCC/gcc/BASE-VER)

--- a/build-common.sh
+++ b/build-common.sh
@@ -127,22 +127,19 @@ saveenvvar () {
     fi
     local varname="$1"
     local newval="$2"
-    # shellcheck disable=SC1083 # \${$varname} intentionally uses literal braces: eval resolves the dynamic variable name at runtime
-    eval local oldval=\"\${$varname}\"
-    # shellcheck disable=SC1083 # \${level_saved_…} intentionally uses literal braces: eval resolves the dynamic variable name at runtime
-    eval local saved=\"\${level_saved_${stack_level}_${varname}}\"
-    # shellcheck disable=SC2154
+    local oldval="${!varname}"
+    local _saved_name="level_saved_${stack_level}_${varname}"
+    local saved="${!_saved_name}"
     if [ "$saved" = "" ]; then
         # The variable wasn't saved in the level before. Save it
-        # shellcheck disable=SC1083 # \${stack_list_…} intentionally uses literal braces: eval resolves the dynamic variable name at runtime
-        eval local temp=\"\${stack_list_$stack_level}\"
-        # shellcheck disable=SC2154
+        local _list_name="stack_list_${stack_level}"
+        local temp="${!_list_name}"
         eval stack_list_$stack_level=\"$varname $temp\"
-        # shellcheck disable=SC2154
         eval save_level_${stack_level}_$varname=\"$oldval\"
         eval level_saved_${stack_level}_$varname="yes"
-        # shellcheck disable=SC1083 # \${$varname+set} intentionally uses literal braces: eval resolves the dynamic variable name and +set modifier at runtime
-        eval level_preset_${stack_level}_${varname}=\"\${$varname+set}\"
+        local _is_set=""
+        [[ -v "$varname" ]] && _is_set="set"
+        printf -v "level_preset_${stack_level}_${varname}" '%s' "$_is_set"
         #echo Save $varname: \"$oldval\"
     fi
     eval export $varname=\"$newval\"
@@ -157,17 +154,15 @@ restoreenv () {
         error "Trying to restore from an empty stack"
     fi
 
-    # shellcheck disable=SC1083 # \${stack_list_…} intentionally uses literal braces: eval resolves the dynamic variable name at runtime
-    eval local list=\"\${stack_list_$stack_level}\"
+    local _list_name="stack_list_${stack_level}"
+    local list="${!_list_name}"
     local varname
-    # shellcheck disable=SC2154
     for varname in $list; do
-        # shellcheck disable=SC1083 # \${level_preset_…} intentionally uses literal braces: eval resolves the dynamic variable name at runtime
-        eval local varname_preset=\"\${level_preset_${stack_level}_${varname}}\"
-        # shellcheck disable=SC2154
+        local _vp_name="level_preset_${stack_level}_${varname}"
+        local varname_preset="${!_vp_name}"
         if [ "$varname_preset" = "set" ] ; then
-            # shellcheck disable=SC1083 # \${save_level_…} intentionally uses literal braces: eval resolves the dynamic variable name at runtime
-            eval $varname=\"\${save_level_${stack_level}_$varname}\"
+            local _restore_name="save_level_${stack_level}_${varname}"
+            printf -v "$varname" '%s' "${!_restore_name}"
         else
             unset $varname
         fi

--- a/build-common.sh
+++ b/build-common.sh
@@ -142,8 +142,7 @@ saveenvvar () {
         printf -v "level_preset_${stack_level}_${varname}" '%s' "$_is_set"
         #echo Save $varname: \"$oldval\"
     fi
-    printf -v "$varname" '%s' "$newval"
-    export "$varname"
+    declare -gx "$varname=$newval"
     #echo $varname set to \"$newval\"
     set -u
 }

--- a/build-common.sh
+++ b/build-common.sh
@@ -111,7 +111,7 @@ saveenv () {
     set +u
     # Force expr return 0 to avoid script fail
     stack_level=$(expr $stack_level \+ 1 || true)
-    eval stack_list_$stack_level=
+    printf -v "stack_list_${stack_level}" '%s' ""
     set -u
 }
 
@@ -134,15 +134,16 @@ saveenvvar () {
         # The variable wasn't saved in the level before. Save it
         local _list_name="stack_list_${stack_level}"
         local temp="${!_list_name}"
-        eval stack_list_$stack_level=\"$varname $temp\"
-        eval save_level_${stack_level}_$varname=\"$oldval\"
-        eval level_saved_${stack_level}_$varname="yes"
+        printf -v "stack_list_${stack_level}" '%s' "$varname $temp"
+        printf -v "save_level_${stack_level}_${varname}" '%s' "$oldval"
+        printf -v "level_saved_${stack_level}_${varname}" '%s' "yes"
         local _is_set=""
         [[ -v "$varname" ]] && _is_set="set"
         printf -v "level_preset_${stack_level}_${varname}" '%s' "$_is_set"
         #echo Save $varname: \"$oldval\"
     fi
-    eval export $varname=\"$newval\"
+    printf -v "$varname" '%s' "$newval"
+    export "$varname"
     #echo $varname set to \"$newval\"
     set -u
 }
@@ -166,8 +167,7 @@ restoreenv () {
         else
             unset $varname
         fi
-        eval level_saved_${stack_level}_$varname=
-        # eval echo $varname restore to \\\"\"\${$varname}\"\\\"
+        printf -v "level_saved_${stack_level}_${varname}" '%s' ""
     done
     # Force expr return 0 to avoid script fail
     stack_level=$(expr $stack_level \- 1 || true)
@@ -176,15 +176,14 @@ restoreenv () {
 
 prependenvvar() {
     set +u
-    eval local oldval=\"\$$1\"
+    local oldval="${!1}"
     saveenvvar "$1" "$2$oldval"
     set -u
 }
 
 prepend_path() {
     set +u
-    eval local old_path="\"\$$1\""
-    # shellcheck disable=SC2154
+    local old_path="${!1}"
     if [ "$old_path" == "" ]; then
         prependenvvar "$1" "$2"
     else

--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -212,8 +212,7 @@ fi
 if [ "$is_ppa_release" != "yes" ]; then
   ENV_CFLAGS=" -I$BUILDDIR_NATIVE/host-libs/zlib/include $BUILD_OPTIONS "
   ENV_CPPFLAGS=" -I$BUILDDIR_NATIVE/host-libs/zlib/include "
-  ENV_LDFLAGS=" -L$BUILDDIR_NATIVE/host-libs/zlib/lib
-                -L$BUILDDIR_NATIVE/host-libs/usr/lib "
+  ENV_LDFLAGS=" -L$BUILDDIR_NATIVE/host-libs/zlib/lib -L$BUILDDIR_NATIVE/host-libs/usr/lib "
 
   GCC_CONFIG_OPTS=" --build=$BUILD --host=$HOST_NATIVE
                     --with-gmp=$BUILDDIR_NATIVE/host-libs/usr

--- a/tests/test-build-common.sh
+++ b/tests/test-build-common.sh
@@ -37,12 +37,12 @@ assert_eq() {
 
 assert_unset() {
     local desc="$1" varname="$2"
-    if eval "[ \"\${${varname}+set}\" != \"set\" ]"; then
+    if [[ ! -v "$varname" ]]; then
         _PASS=$((_PASS + 1))
         echo "  PASS: $desc"
     else
         _FAIL=$((_FAIL + 1))
-        echo "  FAIL: $desc (expected unset, got [$(eval echo \"\$$varname\")])"
+        echo "  FAIL: $desc (expected unset, got [${!varname}])"
     fi
 }
 


### PR DESCRIPTION
… to resolve SC1083

Replace all 8 shellcheck SC1083 violations across build-common.sh and tests/test-build-common.sh with native bash idioms that are functionally identical but shellcheck-compliant, eliminating every per-line # shellcheck disable=SC1083 suppression.

Techniques used:
- ${!varname}          indirect read of a variable whose name is in $varname
- ${!_name}            indirect read of a dynamically-constructed variable name
- [[ -v "$varname" ]]  set-test replacing the ${varname+set} eval pattern
- printf -v "$target"  indirect write replacing eval target=${...}

Companion SC2154 suppressions are also removed as they were only needed because eval-assigned locals were invisible to shellcheck.

## Description

<!-- Describe the changes introduced by this PR and why they are needed. -->

## Testing

<!-- Describe how these changes were tested. -->

## Checklist

- [ ] The PR title follows the Conventional Commits format (see note below)
- [ ] Changes are documented where appropriate

---

> [!IMPORTANT]
> **PR title must follow [Conventional Commits](https://www.conventionalcommits.org/) format.**
>
> PRs are squashed into the target branch using the **PR title** as the commit message.
> The PR title must therefore conform to commitlint requirements:
>
> ```
> <type>[(optional scope)][!]: <description>
> ```
>
> Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`, `perf`, `style`, `revert`
>
> Examples: `feat: add ARMv8-M support`, `fix: correct stack calculation`, `docs: update build instructions`
>
> Individual commits **within** the PR do **not** need to follow this format.
