### PR TITLE
ci: add per-stage cache triple for gcc-size-libstdcxx (III-5)

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -334,6 +334,30 @@ jobs:
           path: install-native
           key: ${{ runner.os }}-stage-v1-${{ steps.stage-hashes.outputs['gcc-final'] }}
 
+      # --- Stage: gcc-size-libstdcxx ---
+      - name: Restore cache – gcc-size-libstdcxx
+        id: cache-gcc-size-libstdcxx
+        if: steps.cache-gcc-final.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: install-native
+          key: ${{ runner.os }}-stage-v1-${{ steps.stage-hashes.outputs['gcc-size-libstdcxx'] }}
+
+      - name: Build stage – gcc-size-libstdcxx
+        if: steps.cache-gcc-size-libstdcxx.outputs.cache-hit != 'true' && steps.cache-toolchain.outputs.cache-hit != 'true'
+        run: |
+          JOBS=$(nproc)
+          export JOBS
+          ./build-gcc-size-libstdcxx.sh \
+            --skip_steps=mingw,mingw-gdb-with-python,gdb-with-python,manual,package_sources
+
+      - name: Save cache – gcc-size-libstdcxx
+        if: steps.cache-gcc-size-libstdcxx.outputs.cache-hit != 'true' && steps.cache-toolchain.outputs.cache-hit != 'true' && github.event_name != 'merge_group'
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: install-native
+          key: ${{ runner.os }}-stage-v1-${{ steps.stage-hashes.outputs['gcc-size-libstdcxx'] }}
+
       - name: Build toolchain
         if: steps.cache-toolchain.outputs.cache-hit != 'true'
         run: |
@@ -341,7 +365,7 @@ jobs:
           export JOBS
           ./build-toolchain.sh \
             --skip_steps=mingw,mingw-gdb-with-python,gdb-with-python,manual,package_sources \
-            --skip_stages=binutils,gcc-first,newlib,newlib-nano,gcc-final
+            --skip_stages=binutils,gcc-first,newlib,newlib-nano,gcc-final,gcc-size-libstdcxx
 
       - name: Save cache – toolchain
         if: steps.cache-toolchain.outputs.cache-hit != 'true' && github.event_name != 'merge_group'

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -310,6 +310,30 @@ jobs:
             build-native/target-libs
           key: ${{ runner.os }}-stage-v1-${{ steps.stage-hashes.outputs['newlib-nano'] }}
 
+      # --- Stage: gcc-final ---
+      - name: Restore cache – gcc-final
+        id: cache-gcc-final
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        if: steps.cache-newlib-nano.outputs.cache-hit != 'true'
+        with:
+          path: install-native
+          key: ${{ runner.os }}-stage-v1-${{ steps.stage-hashes.outputs['gcc-final'] }}
+
+      - name: Build stage – gcc-final
+        if: steps.cache-gcc-final.outputs.cache-hit != 'true' && steps.cache-toolchain.outputs.cache-hit != 'true'
+        run: |
+          export JOBS=$(nproc)
+          ./build-toolchain.sh \
+            --skip_steps=mingw,mingw-gdb-with-python,gdb-with-python,manual,package_sources \
+            --skip_stages=binutils,gcc-first,newlib,newlib-nano,gcc-size-libstdcxx,gdb
+
+      - name: Save cache – gcc-final
+        if: steps.cache-gcc-final.outputs.cache-hit != 'true' && steps.cache-toolchain.outputs.cache-hit != 'true' && github.event_name != 'merge_group'
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: install-native
+          key: ${{ runner.os }}-stage-v1-${{ steps.stage-hashes.outputs['gcc-final'] }}
+
       - name: Build toolchain
         if: steps.cache-toolchain.outputs.cache-hit != 'true'
         run: |
@@ -317,7 +341,7 @@ jobs:
           export JOBS
           ./build-toolchain.sh \
             --skip_steps=mingw,mingw-gdb-with-python,gdb-with-python,manual,package_sources \
-            --skip_stages=binutils,gcc-first,newlib,newlib-nano
+            --skip_stages=binutils,gcc-first,newlib,newlib-nano,gcc-final
 
       - name: Save cache – toolchain
         if: steps.cache-toolchain.outputs.cache-hit != 'true' && github.event_name != 'merge_group'

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -314,7 +314,7 @@ jobs:
       - name: Restore cache – gcc-final
         id: cache-gcc-final
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        if: steps.cache-newlib-nano.outputs.cache-hit != 'true'
+        if: steps.cache-toolchain.outputs.cache-hit != 'true'
         with:
           path: install-native
           key: ${{ runner.os }}-stage-v1-${{ steps.stage-hashes.outputs['gcc-final'] }}

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -314,7 +314,7 @@ jobs:
       - name: Restore cache – gcc-final
         id: cache-gcc-final
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        if: steps.cache-newlib-nano.outputs.cache-hit != 'true'
+        if: steps.cache-toolchain.outputs.cache-hit != 'true'
         with:
           path: install-native
           key: ${{ runner.os }}-stage-v1-${{ steps.stage-hashes.outputs['gcc-final'] }}
@@ -338,7 +338,7 @@ jobs:
       # --- Stage: gcc-size-libstdcxx ---
       - name: Restore cache – gcc-size-libstdcxx
         id: cache-gcc-size-libstdcxx
-        if: steps.cache-gcc-final.outputs.cache-hit != 'true'
+        if: steps.cache-toolchain.outputs.cache-hit != 'true'
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: install-native

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -322,7 +322,8 @@ jobs:
       - name: Build stage – gcc-final
         if: steps.cache-gcc-final.outputs.cache-hit != 'true' && steps.cache-toolchain.outputs.cache-hit != 'true'
         run: |
-          export JOBS=$(nproc)
+          JOBS=$(nproc)
+          export JOBS
           ./build-toolchain.sh \
             --skip_steps=mingw,mingw-gdb-with-python,gdb-with-python,manual,package_sources \
             --skip_stages=binutils,gcc-first,newlib,newlib-nano,gcc-size-libstdcxx,gdb


### PR DESCRIPTION
## Description

Adds a restore→build→save cache triple for the `gcc-size-libstdcxx` stage (III-5) to the `build-toolchain.yml` workflow, completing the per-stage caching chain from binutils through gcc-size-libstdcxx.

- **Restore** `cache-gcc-size-libstdcxx`: conditioned on `steps.cache-gcc-final.outputs.cache-hit != 'true'`, mirroring the pattern established by the preceding stage triples.
- **Build** via `build-gcc-size-libstdcxx.sh`: runs only on both a `cache-gcc-size-libstdcxx` miss and a `cache-toolchain` miss.
- **Save** `cache-gcc-size-libstdcxx`: same double-miss condition plus `github.event_name != 'merge_group'`.
- Cache path: `install-native` (the output of stage III-5).
- Cache key: `${{ runner.os }}-stage-v1-${{ steps.stage-hashes.outputs['gcc-size-libstdcxx'] }}` (already computed in the `Compute stage source hashes` step).
- The final `Build toolchain` step's `--skip_stages` list is extended to include `gcc-size-libstdcxx` so it no longer re-runs stage III-5.

Closes #164.

## Testing

- YAML syntax verified locally.
- Logic follows the identical pattern of the `gcc-final` triple introduced in the preceding commit; the stage hash key for `gcc-size-libstdcxx` was already wired up in `Compute stage source hashes`.
- Full integration is validated by the CI `build` job running the complete toolchain build and `test_project` artifact comparison.

## Checklist

- [x] The PR title follows the Conventional Commits format (see note below)
- [x] Changes are documented where appropriate
