### PR TITLE
ci: remove build-gdb-status job from workflow

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -1635,26 +1635,8 @@ jobs:
           echo "All artifacts match reference binaries."
 
   # ---------------------------------------------------------------------------
-  # Status jobs – keep required checks green when jobs are skipped.
+  # Status job – keep required checks green when jobs are skipped.
   # ---------------------------------------------------------------------------
-  build-gdb-status:
-    runs-on: ubuntu-slim
-    needs: [check-changes, compute-hashes, build-gdb]
-    if: always()
-    steps:
-      - name: Report build-gdb status
-        run: |
-          if [[ "${{ needs.check-changes.result }}" == "failure" || "${{ needs.check-changes.result }}" == "cancelled" ]]; then
-            echo "check-changes job failed or was cancelled" && exit 1
-          fi
-          if [[ "${{ needs.compute-hashes.result }}" == "failure" || "${{ needs.compute-hashes.result }}" == "cancelled" ]]; then
-            echo "compute-hashes job failed or was cancelled" && exit 1
-          fi
-          if [[ "${{ needs.build-gdb.result }}" == "failure" || "${{ needs.build-gdb.result }}" == "cancelled" ]]; then
-            echo "build-gdb failed or was cancelled" && exit 1
-          fi
-          echo "build-gdb skipped or succeeded"
-
   build-status:
     runs-on: ubuntu-slim
     needs: [check-changes, compute-hashes, build-binutils, build-gdb, build-gcc-first, build-newlib, build-newlib-nano, build-gcc-final, build-gcc-size-libstdcxx, build-gcc-chain, build-final]


### PR DESCRIPTION
Removed the build-gdb-status job to streamline the workflow.

## Description

<!-- Describe the changes introduced by this PR and why they are needed. -->

## Testing

<!-- Describe how these changes were tested. -->

## Checklist

- [ ] The PR title follows the Conventional Commits format (see note below)
- [ ] Changes are documented where appropriate

---

> [!IMPORTANT]
> **PR title must follow [Conventional Commits](https://www.conventionalcommits.org/) format.**
>
> PRs are squashed into the target branch using the **PR title** as the commit message.
> The PR title must therefore conform to commitlint requirements:
>
> ```
> <type>[(optional scope)][!]: <description>
> ```
>
> Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`, `perf`, `style`, `revert`
>
> Examples: `feat: add ARMv8-M support`, `fix: correct stack calculation`, `docs: update build instructions`
>
> Individual commits **within** the PR do **not** need to follow this format.
