### PR TITLE
fix: quote $(dirname "$0") and source path in remaining build scripts (SC2046)

### DIFF
--- a/build-binutils.sh
+++ b/build-binutils.sh
@@ -49,10 +49,9 @@ umask 022
 
 exec < /dev/null
 
-# shellcheck disable=SC2046
-script_path=$(cd $(dirname $0) && pwd -P)
+script_path=$(cd "$(dirname "$0")" && pwd -P)
 cd "$script_path"
-. $script_path/build-common.sh
+. "$script_path/build-common.sh"
 
 . "$script_path/build-toolchain-args.sh"
 parse_toolchain_args "$@"

--- a/build-gcc-final.sh
+++ b/build-gcc-final.sh
@@ -52,9 +52,9 @@ umask 022
 
 exec < /dev/null
 
-script_path=$(cd $(dirname $0) && pwd -P)
+script_path=$(cd "$(dirname "$0")" && pwd -P)
 cd "$script_path"
-. $script_path/build-common.sh
+. "$script_path/build-common.sh"
 
 . "$script_path/build-toolchain-args.sh"
 parse_toolchain_args "$@"

--- a/build-gcc-first.sh
+++ b/build-gcc-first.sh
@@ -52,10 +52,9 @@ umask 022
 
 exec < /dev/null
 
-# shellcheck disable=SC2046
-script_path=$(cd $(dirname $0) && pwd -P)
+script_path=$(cd "$(dirname "$0")" && pwd -P)
 cd "$script_path"
-. $script_path/build-common.sh
+. "$script_path/build-common.sh"
 
 . "$script_path/build-toolchain-args.sh"
 parse_toolchain_args "$@"

--- a/build-gcc-size-libstdcxx.sh
+++ b/build-gcc-size-libstdcxx.sh
@@ -54,9 +54,9 @@ umask 022
 
 exec < /dev/null
 
-script_path=$(cd $(dirname $0) && pwd -P)
+script_path=$(cd "$(dirname "$0")" && pwd -P)
 cd "$script_path"
-. $script_path/build-common.sh
+. "$script_path/build-common.sh"
 
 . "$script_path/build-toolchain-args.sh"
 parse_toolchain_args "$@"

--- a/build-prerequisites.sh
+++ b/build-prerequisites.sh
@@ -37,9 +37,8 @@ umask 022
 
 exec < /dev/null
 
-# shellcheck disable=SC2046
-script_path=$(cd $(dirname $0) && pwd -P)
-. $script_path/build-common.sh
+script_path=$(cd "$(dirname "$0")" && pwd -P)
+. "$script_path/build-common.sh"
 
 # This file contains the sequence of commands used to build the prerequisites
 # for GNU Tools Arm Embedded toolchain.

--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -37,9 +37,8 @@ umask 022
 
 exec < /dev/null
 
-# shellcheck disable=SC2046
-script_path=$(cd $(dirname $0) && pwd -P)
-. $script_path/build-common.sh
+script_path=$(cd "$(dirname "$0")" && pwd -P)
+. "$script_path/build-common.sh"
 
 # This file contains the sequence of commands used to build the
 # GNU Tools Arm Embedded toolchain.


### PR DESCRIPTION
This PR applies the same quoting fix already merged in #552 (`build-gdb.sh`) and #555 (`build-newlib-nano.sh`) to the remaining 6 build scripts that still had unquoted `$(dirname $0)` and unquoted source paths.

### Files Simplified

- `build-binutils.sh` — remove inline SC2046 suppression, fix quoting
- `build-gcc-final.sh` — fix quoting (had no suppression, ShellCheck was actively warning)
- `build-gcc-first.sh` — remove inline SC2046 suppression, fix quoting
- `build-gcc-size-libstdcxx.sh` — fix quoting (had no suppression, ShellCheck was actively warning)
- `build-prerequisites.sh` — remove inline SC2046 suppression, fix quoting
- `build-toolchain.sh` — remove inline SC2046 suppression, fix quoting

### Improvements Made

**Consistent quoting across all build scripts:**

```bash
# Before (4 scripts had inline suppression + unquoted pattern)
# shellcheck disable=SC2046
script_path=$(cd $(dirname $0) && pwd -P)
. $script_path/build-common.sh

# Before (2 scripts had no suppression, ShellCheck was warning SC2046)
script_path=$(cd $(dirname $0) && pwd -P)
. $script_path/build-common.sh

# After (all 6 scripts now consistent with build-gdb.sh and build-newlib-nano.sh)
script_path=$(cd "$(dirname "$0")" && pwd -P)
. "$script_path/build-common.sh"
```

The inline `# shellcheck disable=SC2046` suppressions are removed since proper quoting makes them unnecessary.

### Changes Based On

Directly extends recent fixes:
- #552 — fix: quote `$(dirname "$0")` in `build-gdb.sh`
- #555 — fix: quote `$(dirname $0)` in `build-newlib-nano.sh`

### Testing

- ✅ All tests pass (`tests/test-build-common.sh`: 59 passed, `tests/test-build-toolchain-args.sh`: 86 passed, `tests/test-strip-binary.sh`: 13 passed)
- ✅ Shell syntax valid (`bash -n` passes for all 6 modified scripts)
- ✅ `shellcheck` reports no SC2046 warnings in the modified scripts
- ✅ No functional changes — behavior is identical

### Review Focus

Please verify:
- Quoting is correct and consistent with `build-gdb.sh` and `build-newlib-nano.sh`
- Inline suppression removals are appropriate (the proper fix replaces the suppression)
- No unintended side effects

---

**References:** [§23134971110](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23134971110)

*Automated by Code Simplifier Agent — analyzing code from the last 24 hours*


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23134971110) · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/github/gh-aw/tree/f5aa6a7699752651789e8c80c9d24f8e9fa31809/.github/workflows/code-simplifier.md), run
> ```
> gh aw add github/gh-aw/.github/workflows/code-simplifier.md@f5aa6a7699752651789e8c80c9d24f8e9fa31809
> ```
> - [ ] expires <!-- gh-aw-expires: 2026-03-17T08:52:07.464Z --> on Mar 17, 2026, 8:52 AM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, id: 23134971110, workflow_id: code-simplifier, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23134971110 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->