### PR TITLE
refactor: standardize compute_key_final local declaration style

### DIFF
--- a/tests/test-build-toolchain-cache-keys.sh
+++ b/tests/test-build-toolchain-cache-keys.sh
@@ -70,10 +70,7 @@ compute_key_gdb() {
 }
 
 compute_key_final() {
-    local final_scripts_hash="$1"
-    local key_gcc_size="$2"
-    local key_gdb="$3"
-    local specs_src="$4"
+    local final_scripts_hash="$1" key_gcc_size="$2" key_gdb="$3" specs_src="$4"
     _sha256 "Linux-stage-final-${final_scripts_hash}-${key_gcc_size}-${key_gdb}-${specs_src}"
 }
 


### PR DESCRIPTION
### Overview

Aligns `compute_key_final` with the single combined `local` declaration style used by all seven other `compute_key_*` helpers in the same file — including `compute_key_gcc_size`, which also takes four parameters.

### Files Simplified

- `tests/test-build-toolchain-cache-keys.sh` — standardized `local` declaration style in `compute_key_final`

### Improvement

**Before** (4 separate declarations):
```bash
compute_key_final() {
    local final_scripts_hash="$1"
    local key_gcc_size="$2"
    local key_gdb="$3"
    local specs_src="$4"
    _sha256 "Linux-stage-final-..."
}
```

**After** (combined declaration matching all other helpers):
```bash
compute_key_final() {
    local final_scripts_hash="$1" key_gcc_size="$2" key_gdb="$3" specs_src="$4"
    _sha256 "Linux-stage-final-..."
}
```

All 8 `compute_key_*` helpers now follow the same local-variable declaration pattern, making the file consistently formatted throughout.

### Changes Based On

Recent changes from:
- #573 — test: expand cache-key tests to full dependency chain and add assert_ne to test-helpers

### Testing

- ✅ All 19 cache-key tests pass (`bash tests/test-build-toolchain-cache-keys.sh`)
- ✅ Full test suite passes (`for t in tests/test-*.sh; do bash "$t"; done` — 177 assertions pass, 0 fail)
- ✅ Shell syntax valid (`bash -n` passes)
- ✅ No warnings from `shellcheck -S warning` — only pre-existing SC1091 info notice
- ✅ No functional changes — identical runtime behavior

### Review Focus

Please verify:
- Combined `local` style is consistent with project conventions
- No unintended side effects

**References:** [§23185401616](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23185401616)

---

*Automated by Code Simplifier Agent — analyzing code from the last 24 hours*


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23185401616) · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/github/gh-aw/tree/f5aa6a7699752651789e8c80c9d24f8e9fa31809/.github/workflows/code-simplifier.md), run
> ```
> gh aw add github/gh-aw/.github/workflows/code-simplifier.md@f5aa6a7699752651789e8c80c9d24f8e9fa31809
> ```
> - [x] expires <!-- gh-aw-expires: 2026-03-18T08:44:27.434Z --> on Mar 18, 2026, 8:44 AM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, id: 23185401616, workflow_id: code-simplifier, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23185401616 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->