### PR TITLE
refactor: simplify strip_binary conditional and fix printf format in tests

### DIFF
--- a/build-common.sh
+++ b/build-common.sh
@@ -235,8 +235,7 @@ strip_binary() {
     local strip="$1"
     local bin="$2"
 
-    file "$bin" | grep -q -e "\bELF\b" -e "\bPE\b" -e "\bPE32\b" -e "\bMach-O\b"
-    if [ $? -eq 0 ]; then
+    if file "$bin" | grep -q -e "\bELF\b" -e "\bPE\b" -e "\bPE32\b" -e "\bMach-O\b"; then
         "$strip" "$bin" 2>/dev/null || true
     fi
 

--- a/tests/test-build-common.sh
+++ b/tests/test-build-common.sh
@@ -420,7 +420,7 @@ for _mdir in "." "thumb/v8-m.main/fp"; do
     for _spec in nano.specs rdimon.specs nosys.specs; do
         printf '%s' "${_spec}" > "${_CML_TMPDIR}/src/${_mdir}/${_spec}"
     done
-    printf 'crt0' > "${_CML_TMPDIR}/src/${_mdir}/crt0.o"
+    printf '%s' 'crt0' > "${_CML_TMPDIR}/src/${_mdir}/crt0.o"
 done
 
 copy_multi_libs \


### PR DESCRIPTION
This PR simplifies recently modified code (PRs #568 and #582, merged in the last 24 hours) to improve clarity and consistency while preserving all functionality.

### Files Simplified

- `build-common.sh` — replace indirect `$?` check with direct conditional in `strip_binary`
- `tests/test-build-common.sh` — use explicit `%s` format in `printf` call in group 14

### Improvements Made

#### 1. Direct conditional in `strip_binary` (SC2181)

PR #568 added quoting to `strip_binary` but left behind the indirect `$?` check pattern flagged by ShellCheck SC2181:

```bash
# Before
file "$bin" | grep -q -e "\bELF\b" -e "\bPE\b" -e "\bPE32\b" -e "\bMach-O\b"
if [ $? -eq 0 ]; then

# After
if file "$bin" | grep -q -e "\bELF\b" -e "\bPE\b" -e "\bPE32\b" -e "\bMach-O\b"; then
```

The direct form is more idiomatic shell and eliminates the dependency on `$?` being unmodified between the pipeline and the `if`. Behaviour is identical: the function has `set +e` in effect, so the pipeline exit status is checked in both cases.

#### 2. Consistent `printf` format in test group 14

PR #582 added group 14 tests for `copy_multi_libs`. The other file-creation calls in the group use the explicit `printf '%s' "\$\{var}"` form (lines 417 and 421), but `crt0.o` used the bare `printf 'crt0'` form. Changed to match:

```bash
# Before
printf 'crt0' > "\$\{_CML_TMPDIR}/src/\$\{_mdir}/crt0.o"

# After
printf '%s' 'crt0' > "\$\{_CML_TMPDIR}/src/\$\{_mdir}/crt0.o"
```

### Changes Based On

Recent changes from:
- #568 — `fix: resolve all 48 SC2086 (unquoted variable) findings in build-common.sh`
- #582 — `test: add copy_multi_libs unit tests (group 14)`

### Testing

- ✅ All tests pass: `tests/test-build-common.sh` (75 passed), `tests/test-strip-binary.sh` (13 passed), `tests/test-build-toolchain-args.sh` (86 passed), `tests/test-build-toolchain-cache-keys.sh` (19 passed)
- ✅ Shell syntax valid (`bash -n` passes for each modified file)
- ✅ ShellCheck passes at `--severity=warning` for `build-common.sh`
- ✅ No functional changes — behaviour is identical

### Review Focus

Please verify:
- `strip_binary` conditional change preserves identical behaviour (it does — `set +e` is active in both before/after cases)
- `printf '%s' 'crt0'` is consistent with the rest of group 14

---

*Automated by Code Simplifier Agent — analysing code from the last 24 hours*


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23235860490) · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/github/gh-aw/tree/f5aa6a7699752651789e8c80c9d24f8e9fa31809/.github/workflows/code-simplifier.md), run
> ```
> gh aw add github/gh-aw/.github/workflows/code-simplifier.md@f5aa6a7699752651789e8c80c9d24f8e9fa31809
> ```
> - [x] expires <!-- gh-aw-expires: 2026-03-19T08:41:52.025Z --> on Mar 19, 2026, 8:41 AM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, id: 23235860490, workflow_id: code-simplifier, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23235860490 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->