### PR TITLE
test: fix test isolation in test-build-cache-budget-check.sh

### DIFF
--- a/tests/test-build-cache-budget-check.sh
+++ b/tests/test-build-cache-budget-check.sh
@@ -33,10 +33,14 @@ dd if=/dev/zero of="${_TMPDIR}/build-native/target-libs/dummy" bs=1024 count=512
 # supplied environment variable overrides.  Arguments are VAR=value pairs
 # passed to env(1).  Uses a portable subshell+cd rather than GNU env -C so the
 # tests work on macOS/BSD as well as Linux.
+#
+# GITHUB_STEP_SUMMARY is always cleared so that the script does not try to
+# append to the CI runner's summary file (which may not be writable or may not
+# exist when running tests in a different subprocess context).
 run_check() {
     local dir="$1"
     shift
-    (cd "${dir}" && exec env "$@" bash "${REPO_ROOT}/build-cache-budget-check.sh")
+    (cd "${dir}" && exec env GITHUB_STEP_SUMMARY="" "$@" bash "${REPO_ROOT}/build-cache-budget-check.sh")
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant*

## Problem

Three tests in `tests/test-build-cache-budget-check.sh` fail when run inside a GitHub Actions runner:

```
FAIL: exits 0 when both directories are below fail threshold (expected zero exit)
FAIL: exits 0 when install-native is in warn zone (above warn, below fail) (expected zero exit)
FAIL: exits 0 when cache directories do not exist (expected zero exit)
```

**Root cause**: The runner sets `GITHUB_STEP_SUMMARY` to a path like `/home/runner/work/_temp/_runner_file_commands/step_summary_(uuid)`. The `run_check()` helper inherits this from the environment. When `build-cache-budget-check.sh` (which uses `set -euo pipefail`) tries to append to that path, it fails because the parent directory doesn't exist in the subprocess context — causing a non-zero exit where exit 0 was expected.

## Fix

Override `GITHUB_STEP_SUMMARY=""` in `run_check()` so Groups 1–5 (which don't test summary output) are isolated from the CI runner's environment. Group 6 continues to set its own explicit temp file path.

```bash
# Before
(cd "\$\{dir}" && exec env "$@" bash "\$\{REPO_ROOT}/build-cache-budget-check.sh")

# After
(cd "\$\{dir}" && exec env GITHUB_STEP_SUMMARY="" "$@" bash "\$\{REPO_ROOT}/build-cache-budget-check.sh")
```

## Test Status

| Suite | Before | After |
|-------|--------|-------|
| test-build-cache-budget-check.sh | 6 passed, **3 failed** | **9 passed, 0 failed** |
| All other suites | unchanged | unchanged |

**Total: 226 tests, 0 failed** (was 223 passed, 3 failed)

## Reproduce

```bash
bash tests/test-build-cache-budget-check.sh
```




> Generated by [Daily Test Improver](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23280973990) · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, id: 23280973990, workflow_id: daily-test-improver, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23280973990 -->

<!-- gh-aw-workflow-id: daily-test-improver -->