### PR TITLE
refactor: simplify ELF-strip loops and extract make_mock_strip helper

### DIFF
--- a/build-pre-cache-clean.sh
+++ b/build-pre-cache-clean.sh
@@ -97,9 +97,7 @@ for bin_dir in \
 do
     if [ -d "$bin_dir" ]; then
         while IFS= read -r -d '' file; do
-            if [ -f "$file" ] && [ ! -L "$file" ]; then
-                strip_elf_file "$file"
-            fi
+            strip_elf_file "$file"
         done < <(find "$bin_dir" -maxdepth 1 -type f -print0)
     fi
 done
@@ -108,9 +106,7 @@ done
 # libexec/gcc/<target>/<version>/ (cc1, cc1plus, lto1, …).
 if [ -d "$root_dir/libexec" ]; then
     while IFS= read -r -d '' file; do
-        if [ -f "$file" ] && [ ! -L "$file" ]; then
-            strip_elf_file "$file"
-        fi
+        strip_elf_file "$file"
     done < <(find "$root_dir/libexec" -type f -print0)
 fi
 

--- a/tests/test-pre-cache-clean.sh
+++ b/tests/test-pre-cache-clean.sh
@@ -29,6 +29,18 @@ make_ar() {
     printf '!<arch>\n' > "$1"
 }
 
+# Helper: create a mock strip binary in the given directory that logs its
+# arguments to the file referenced by ${STRIP_LOG}.
+make_mock_strip() {
+    local mock_dir="$1"
+    mkdir -p "$mock_dir"
+    cat > "$mock_dir/strip" <<'STRIPEOF'
+#!/usr/bin/env bash
+echo "$*" >> "${STRIP_LOG}"
+STRIPEOF
+    chmod +x "$mock_dir/strip"
+}
+
 # ---------------------------------------------------------------------------
 # Test group 1: Missing argument → non-zero exit
 # ---------------------------------------------------------------------------
@@ -79,14 +91,7 @@ chmod +x "$_TEXT_FILE"
 # Capture invocations of strip via PATH override
 _STRIP_LOG3="$_TMPDIR/strip-calls-3"
 _MOCK_BIN3="$_TMPDIR/mockbin3"
-mkdir -p "$_MOCK_BIN3"
-
-# Mock strip: records "--strip-unneeded <path>" or "--strip-debug <path>" calls
-cat > "$_MOCK_BIN3/strip" <<'STRIPEOF'
-#!/usr/bin/env bash
-echo "$*" >> "${STRIP_LOG}"
-STRIPEOF
-chmod +x "$_MOCK_BIN3/strip"
+make_mock_strip "$_MOCK_BIN3"
 
 export STRIP_LOG="$_STRIP_LOG3"
 _SAVED_PATH3="$PATH"
@@ -124,13 +129,7 @@ make_ar "$_AR"
 
 _STRIP_LOG4="$_TMPDIR/strip-calls-4"
 _MOCK_BIN4="$_TMPDIR/mockbin4"
-mkdir -p "$_MOCK_BIN4"
-
-cat > "$_MOCK_BIN4/strip" <<'STRIPEOF'
-#!/usr/bin/env bash
-echo "$*" >> "${STRIP_LOG}"
-STRIPEOF
-chmod +x "$_MOCK_BIN4/strip"
+make_mock_strip "$_MOCK_BIN4"
 
 export STRIP_LOG="$_STRIP_LOG4"
 _SAVED_PATH4="$PATH"


### PR DESCRIPTION
This PR simplifies two recently merged files (from PR #584) to improve clarity and remove redundancy while preserving all functionality.

### Files Simplified

- `build-pre-cache-clean.sh` — remove dead-code file-type guards from ELF-stripping loops
- `tests/test-pre-cache-clean.sh` — extract `make_mock_strip` helper to eliminate duplicated setup

### Improvements Made

#### 1. Removed redundant file-type guards (`build-pre-cache-clean.sh`)

The ELF-stripping loops contained `[ -f "$file" ] && [ ! -L "$file" ]` guards inside `while IFS= read -r -d '' file; do … done < <(find … -type f …)`. Because `find -type f` already restricts output to regular (non-symlink) files, these checks were always true and could never filter anything out. Removing them reduces visual noise and makes the loop body a single-line call to `strip_elf_file`.

**Before:**
```bash
while IFS= read -r -d '' file; do
    if [ -f "$file" ] && [ ! -L "$file" ]; then
        strip_elf_file "$file"
    fi
done < <(find "$bin_dir" -maxdepth 1 -type f -print0)
```

**After:**
```bash
while IFS= read -r -d '' file; do
    strip_elf_file "$file"
done < <(find "$bin_dir" -maxdepth 1 -type f -print0)
```

#### 2. Extracted `make_mock_strip` helper (`tests/test-pre-cache-clean.sh`)

Groups 3 and 4 each contained an identical 6-line block that created a mock `strip` binary (heredoc + `chmod +x`). Extracting this into a `make_mock_strip` function removes the duplication and makes each group's setup a single descriptive call.

**Before (repeated twice):**
```bash
mkdir -p "$_MOCK_BIN"
cat > "$_MOCK_BIN/strip" <<'STRIPEOF'
#!/usr/bin/env bash
echo "$*" >> "\$\{STRIP_LOG}"
STRIPEOF
chmod +x "$_MOCK_BIN/strip"
```

**After:**
```bash
make_mock_strip "$_MOCK_BIN"
```

### Changes Based On

Recent changes from:
- #584 — build: add pre-cache cleanup script to strip binaries and remove non-essential files

### Testing

- ✅ All 24 tests pass (`bash tests/test-pre-cache-clean.sh`)
- ✅ Shell syntax valid (`bash -n` passes for each modified script)
- ✅ No functional changes — behaviour is identical

### Review Focus

Please verify:
- Redundancy of the removed guards (confirmed: `find -type f` ≡ regular-file-only)
- `make_mock_strip` helper contract is clear from its doc comment
- No unintended side effects

---

*Automated by Code Simplifier Agent — [§23286193435](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23286193435)*


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23286193435) · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/github/gh-aw/tree/f5aa6a7699752651789e8c80c9d24f8e9fa31809/.github/workflows/code-simplifier.md), run
> ```
> gh aw add github/gh-aw/.github/workflows/code-simplifier.md@f5aa6a7699752651789e8c80c9d24f8e9fa31809
> ```

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `pypi.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>

> - [ ] expires <!-- gh-aw-expires: 2026-03-20T08:34:01.733Z --> on Mar 20, 2026, 8:34 AM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, id: 23286193435, workflow_id: code-simplifier, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23286193435 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->