### PR TITLE
test: add safety-check failure test to test-pre-cache-clean.sh (group 11)

### DIFF
--- a/tests/test-pre-cache-clean.sh
+++ b/tests/test-pre-cache-clean.sh
@@ -280,6 +280,34 @@ assert_eq "no safety-check-passed message when gcc absent" "" \
     "$(echo "$_OUTPUT10" | grep -F 'Safety check' || true)"
 
 # ---------------------------------------------------------------------------
+# Test group 11: Safety check fails when arm-none-eabi-gcc was present before
+#                cleanup but is gone afterwards (broken symlink scenario)
+#
+# Simulate a regression where a cleanup operation removes a target that the
+# gcc binary symlink points to.  The safety check must detect this and exit 1.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 11: Safety check FAILED when gcc missing after cleanup ==="
+
+_ROOT11="$_TMPDIR/root11"
+mkdir -p "$_ROOT11/bin"
+mkdir -p "$_ROOT11/share/gcc-14.3.1"
+
+# Place a "gcc" file inside share/gcc-14.3.1/ — a directory that
+# remove_non_essential_dirs will delete — and point bin/arm-none-eabi-gcc at
+# it via a symlink.  After the script removes share/gcc-14.3.1/ the symlink
+# becomes broken, triggering the safety-check failure path.
+echo "fake-gcc" > "$_ROOT11/share/gcc-14.3.1/arm-none-eabi-gcc"
+ln -s "../share/gcc-14.3.1/arm-none-eabi-gcc" "$_ROOT11/bin/arm-none-eabi-gcc"
+
+_root11_exit=0
+_OUTPUT11=$(bash "$SCRIPT" "$_ROOT11" 2>&1) || _root11_exit=$?
+assert_ne "safety check FAILED: script exits non-zero" "0" "$_root11_exit"
+assert_ne "safety check FAILED message emitted" "" \
+    "$(echo "$_OUTPUT11" | grep -F 'Safety check FAILED' || true)"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/tests/test-pre-cache-clean.sh
+++ b/tests/test-pre-cache-clean.sh
@@ -303,7 +303,7 @@ ln -s "../share/gcc-14.3.1/arm-none-eabi-gcc" "$_ROOT11/bin/arm-none-eabi-gcc"
 
 _root11_exit=0
 _OUTPUT11=$(bash "$SCRIPT" "$_ROOT11" 2>&1) || _root11_exit=$?
-assert_ne "safety check FAILED: script exits non-zero" "0" "$_root11_exit"
+assert_eq "safety check FAILED: script exits with status 1" "1" "$_root11_exit"
 assert_ne "safety check FAILED message emitted" "" \
     "$(echo "$_OUTPUT11" | grep -F 'Safety check FAILED' || true)"
 


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant*

## Goal and Rationale

`build-pre-cache-clean.sh` contains a safety check (added in #618) that detects when `arm-none-eabi-gcc` was present before cleanup but is missing afterwards, and exits 1 with an error message. This exit-1 branch had **no test coverage** — only the success path (group 9: gcc survives) and the "gcc never present" path (group 10) were tested.

This PR adds **Group 11** to `tests/test-pre-cache-clean.sh` to cover the failure path, ensuring the safety mechanism actually works.

## Approach

The test uses a broken-symlink scenario to trigger the failure naturally:

1. `bin/arm-none-eabi-gcc` is created as a symlink → `../share/gcc-14.3.1/arm-none-eabi-gcc`
2. `share/gcc-14.3.1/arm-none-eabi-gcc` exists, so `[ -e bin/arm-none-eabi-gcc ]` is `true` before cleanup — `_gcc_present_before=true`
3. `remove_non_essential_dirs()` deletes `share/gcc-14.3.1/` (the `share/gcc-*/` glob)
4. The symlink becomes broken; `[ -e bin/arm-none-eabi-gcc ]` now returns `false`
5. The script must print `Safety check FAILED:` and exit 1

This exercises a real defensive code path without requiring any mocks.

## Coverage Impact

| File | Tests before | Tests after |
|------|-------------|-------------|
| `test-pre-cache-clean.sh` | 32 | 34 |
| Total bash tests | 247 | 249 |

## Reproducibility

````bash
bash tests/test-pre-cache-clean.sh
```

Expected output:
```
=== Group 11: Safety check FAILED when gcc missing after cleanup ===
  PASS: safety check FAILED: script exits non-zero
  PASS: safety check FAILED message emitted

Results: 34 passed, 0 failed
````

## Test Status

✅ All 249 bash tests pass. ✅ All 22 pytest tests pass.




> Generated by [Daily Test Improver](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23396287183) · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, id: 23396287183, workflow_id: daily-test-improver, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23396287183 -->

<!-- gh-aw-workflow-id: daily-test-improver -->