### PR TITLE
[code-simplifier] refactor: remove redundant inline SC2034 suppressions from build-common.sh

### DIFF
--- a/build-common.sh
+++ b/build-common.sh
@@ -344,7 +344,7 @@ LIBICONV_URL=https://ftp.gnu.org/pub/gnu/libiconv/$LIBICONV_PACK
 ZLIB_URL=http://www.zlib.net/fossils/$ZLIB_PACK
 PYTHON_WIN_URL=https://www.python.org/ftp/python/$PYTHON_WIN_VER/$PYTHON_WIN_PACK
 
-# shellcheck disable=SC2034  # consumed by build-toolchain.sh
+# consumed by build-toolchain.sh
 TAR=tar
 # Set variables according to real environment to make this script can run
 # on Ubuntu and Mac OS X.
@@ -353,11 +353,11 @@ host_arch=$(uname -m | sed 'y/XI/xi/')
 if [ "$uname_string" == "linux" ] ; then
     BUILD="$host_arch"-linux-gnu
     HOST_NATIVE="$host_arch"-linux-gnu
-    # shellcheck disable=SC2034  # consumed by build-toolchain.sh and build-prerequisites.sh
+    # consumed by build-toolchain.sh and build-prerequisites.sh
     JOBS=$(grep ^processor /proc/cpuinfo|wc -l)
-    # shellcheck disable=SC2034  # consumed by build-gcc-first.sh, build-gcc-final.sh, build-gcc-size-libstdcxx.sh
+    # consumed by build-gcc-first.sh, build-gcc-final.sh, build-gcc-size-libstdcxx.sh
     GCC_CONFIG_OPTS_LCPP="--with-host-libstdcxx=-static-libgcc -Wl,-Bstatic,-lstdc++,-Bdynamic -lm"
-    # shellcheck disable=SC2034  # consumed by build-toolchain.sh
+    # consumed by build-toolchain.sh
     MD5="md5sum -b"
     PACKAGE_NAME_SUFFIX="${host_arch}-linux"
 elif [ "$uname_string" == "darwin" ] ; then
@@ -365,14 +365,14 @@ elif [ "$uname_string" == "darwin" ] ; then
     HOST_NATIVE=x86_64-apple-darwin10
     # Disable parallel build for mac as we will randomly run into "Permission denied" issue.
     #JOBS=`sysctl -n hw.ncpu`
-    # shellcheck disable=SC2034  # consumed by build-toolchain.sh and build-prerequisites.sh
+    # consumed by build-toolchain.sh and build-prerequisites.sh
     JOBS=1
-    # shellcheck disable=SC2034  # consumed by build-gcc-first.sh, build-gcc-final.sh, build-gcc-size-libstdcxx.sh
+    # consumed by build-gcc-first.sh, build-gcc-final.sh, build-gcc-size-libstdcxx.sh
     GCC_CONFIG_OPTS_LCPP="--with-host-libstdcxx=-static-libgcc -Wl,-lstdc++ -lm"
-    # shellcheck disable=SC2034  # consumed by build-toolchain.sh
+    # consumed by build-toolchain.sh
     MD5="md5 -r"
     PACKAGE_NAME_SUFFIX=mac-$(sw_vers -productVersion)
-    # shellcheck disable=SC2034  # consumed by build-toolchain.sh
+    # consumed by build-toolchain.sh
     TAR=gtar
 else
     error "Unsupported build system : $uname_string"
@@ -407,7 +407,7 @@ if [[ "${SCRIPT%%-*}" = "build" || "${SCRIPT#*_*}" = "build" ]]; then
     STM32_TOOLS_VER=$(git describe --tags 2>/dev/null || echo "$GCC_VER_DISPLAY-$RELEASEVER~$(git rev-parse --verify HEAD)")
 
     HOST_MINGW=x86_64-w64-mingw32
-    # shellcheck disable=SC2034  # consumed by build-toolchain.sh and build-prerequisites.sh
+    # consumed by build-toolchain.sh and build-prerequisites.sh
     HOST_MINGW_TOOL=x86_64-w64-mingw32
     TARGET=arm-none-eabi
     ENV_CFLAGS=


### PR DESCRIPTION
### Overview

PR [#562](https://github.com/grahame-org/gnu-tools-for-stm32/pull/562) established that SC2034 is globally disabled in `.shellcheckrc`:

```
# SC2034 – variable assigned but never used: the build-common.sh "setup"
#          section intentionally sets exported env-var constants consumed by
#          the sourcing scripts (build-toolchain.sh, build-prerequisites.sh).
disable=SC2034
```

With this global suppression in place, the 9 inline `# shellcheck disable=SC2034` comment prefixes remaining in `build-common.sh` are redundant — they provide no additional suppression effect. This PR removes that noise while retaining the valuable `# consumed by ...` documentation comments that identify which scripts use each variable.

### Files Simplified

- `build-common.sh` — Removed redundant `# shellcheck disable=SC2034  ` prefix from 9 inline comments; `# consumed by ...` annotations preserved.

### Improvements Made

1. **Reduced Noise** — Eliminated 9 redundant ShellCheck suppression directives that were already covered globally by `.shellcheckrc`.
2. **Maintained Documentation** — The `# consumed by (script)` annotations are kept intact so readers still know which sourcing script uses each variable.
3. **Consistent Pattern** — The file now uses one consistent approach for SC2034: the global disable in `.shellcheckrc` (with its explanatory comment) rather than a mix of global + repeated inline suppressions.

### Based On

Recent changes from:
- #562 — `fix: suppress SC2034 warnings for tool-detection variables in build-common.sh`

### Testing

- ✅ All tests pass (`tests/test-build-common.sh`: 75, `tests/test-build-toolchain-args.sh`: 87, `tests/test-build-toolchain-cache-keys.sh`: 19, all others: pass)
- ✅ Shell syntax valid (`bash -n build-common.sh`)
- ✅ No new ShellCheck warnings introduced (pre-existing SC2003/SC1001/SC2317/SC2126 unchanged)
- ✅ No functional changes — only comments modified

### Review Focus

Please verify:
- The `# consumed by ...` documentation is preserved and accurate
- No ShellCheck regressions are introduced

---

**References:** [§23428392740](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23428392740)

*Automated by Code Simplifier Agent - analyzing code from the last 24 hours*


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23428392740) · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/github/gh-aw/tree/f5aa6a7699752651789e8c80c9d24f8e9fa31809/.github/workflows/code-simplifier.md), run
> ```
> gh aw add github/gh-aw/.github/workflows/code-simplifier.md@f5aa6a7699752651789e8c80c9d24f8e9fa31809
> ```
> - [x] expires <!-- gh-aw-expires: 2026-03-24T08:45:24.894Z --> on Mar 24, 2026, 8:45 AM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, id: 23428392740, workflow_id: code-simplifier, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23428392740 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->