### PR TITLE
refactor: simplify pack_dir_clean variadic args using "\$\{@:4}"

### DIFF
--- a/build-common.sh
+++ b/build-common.sh
@@ -65,7 +65,7 @@ copy_dir_clean() {
 #   parameter 3: target package name
 #   parameter 4+: additional --exclude arguments (optional, any number)
 # This function will create bz2 package for files under param1/param2,
-# excluding unnecessary parts, and create package named param2.
+# excluding unnecessary parts, and write the package to the path given in param3.
 pack_dir_clean() {
     tar cjfh "$3" \
         --exclude=CVS --exclude=.svn --exclude=.git --exclude=.pc \

--- a/build-common.sh
+++ b/build-common.sh
@@ -63,17 +63,15 @@ copy_dir_clean() {
 #   parameter 1: base dir of the source tree
 #   parameter 2: dirname of the source tree
 #   parameter 3: target package name
-#   parameter 4-10: additional excluding
+#   parameter 4+: additional --exclude arguments (optional, any number)
 # This function will create bz2 package for files under param1/param2,
 # excluding unnecessary parts, and create package named param2.
 pack_dir_clean() {
-    set +u
     tar cjfh "$3" \
         --exclude=CVS --exclude=.svn --exclude=.git --exclude=.pc \
         --exclude="*~" --exclude=".#*" \
-        --exclude="*.orig" --exclude="*.rej" ${4:+"$4"} ${5:+"$5"} ${6:+"$6"} ${7:+"$7"} ${8:+"$8"} ${9:+"$9"} ${10:+"${10}"} \
+        --exclude="*.orig" --exclude="*.rej" "${@:4}" \
         -C "$1" "$2"
-    set -u
 }
 
 # Clean all global shell variables except for those needed by build scripts

--- a/build-common.sh
+++ b/build-common.sh
@@ -62,7 +62,7 @@ copy_dir_clean() {
 # Create source package excluding source control information
 #   parameter 1: base dir of the source tree
 #   parameter 2: dirname of the source tree
-#   parameter 3: target package name
+#   parameter 3: output archive path (including filename)
 #   parameter 4+: additional --exclude arguments (optional, any number)
 # This function will create bz2 package for files under param1/param2,
 # excluding unnecessary parts, and write the package to the path given in param3.

--- a/tests/test-build-common.sh
+++ b/tests/test-build-common.sh
@@ -381,6 +381,16 @@ assert_eq "pack_dir_clean excludes *.rej files" \
 assert_eq "pack_dir_clean excludes .#* emacs lock files" \
     "" "$(echo "$_PDC_CONTENTS" | grep "\.#lockfile" || true)"
 
+# Test that extra --exclude args (params 4+) are forwarded to tar
+_PDC_EXTRA_ARCHIVE="$_PDC_TMPDIR/out-extra.tar.bz2"
+echo "extra-excluded" > "$_PDC_TMPDIR/src/extra.txt"
+pack_dir_clean "$_PDC_TMPDIR" "src" "$_PDC_EXTRA_ARCHIVE" --exclude="extra.txt"
+_PDC_EXTRA_CONTENTS=$(tar tjf "$_PDC_EXTRA_ARCHIVE")
+assert_eq "pack_dir_clean forwards extra --exclude args" \
+    "" "$(echo "$_PDC_EXTRA_CONTENTS" | grep -Fx "src/extra.txt" || true)"
+assert_eq "pack_dir_clean still archives normal files with extra excludes" \
+    "src/normal.txt" "$(echo "$_PDC_EXTRA_CONTENTS" | grep -Fx "src/normal.txt" || true)"
+
 rm -rf "$_PDC_TMPDIR"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR follows up on #559 ("fix: quote positional params in pack_dir_clean, use conditional expansion for variadic args") with a further simplification to the same function.

### Files Simplified

- `build-common.sh` — `pack_dir_clean`: replaced 7 individual `\$\{N:+"$N"}` expansions with `"\$\{@:4}"`
- `tests/test-build-common.sh` — added 2 tests covering the extra-exclude forwarding path

### Improvements Made

#### Reduced Complexity
The function previously handled optional parameters 4–10 by repeating the same conditional-expansion pattern seven times on a single long line:

```sh
\$\{4:+"$4"} \$\{5:+"$5"} \$\{6:+"$6"} \$\{7:+"$7"} \$\{8:+"$8"} \$\{9:+"$9"} \$\{10:+"\$\{10}"}
```

This is replaced with the idiomatic bash array-slice:

```sh
"\$\{@:4}"
```

#### Removed Unnecessary Guards
The `set +u` / `set -u` pair was needed only to suppress "unbound variable" errors from the manual positional-parameter access. `"\$\{@:4}"` expands safely to nothing when fewer than 4 arguments are passed, so the guards are no longer required.

#### Removed Artificial Limit
The previous implementation silently discarded any arguments beyond `$10`. The new implementation forwards all arguments from position 4 onward.

#### Added Tests
Two new assertions cover the previously untested code path where extra `--exclude` arguments are forwarded to `tar`.

### Changes Based On

- #559 — fix: quote positional params in pack\_dir\_clean, use conditional expansion for variadic args

### Testing

- ✅ All 77 tests pass (`tests/test-build-common.sh`: 75 original + 2 new)
- ✅ Shell syntax valid (`bash -n build-common.sh` passes)
- ✅ No new ShellCheck warnings introduced
- ✅ No functional changes for existing callers in `build-toolchain.sh`

### Review Focus

Please verify:
- Functionality is preserved for the two callers in `build-toolchain.sh` (lines 564–568)
- `"\$\{@:4}"` expansion is equivalent to the old conditional expansions for non-empty arguments
- New tests adequately cover the extra-exclude forwarding path

---

*Automated by Code Simplifier Agent — analysing code from the last 24 hours*

**References:** [§23531986842](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23531986842)


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23531986842) · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/github/gh-aw/tree/f5aa6a7699752651789e8c80c9d24f8e9fa31809/.github/workflows/code-simplifier.md), run
> ```
> gh aw add github/gh-aw/.github/workflows/code-simplifier.md@f5aa6a7699752651789e8c80c9d24f8e9fa31809
> ```
> - [x] expires <!-- gh-aw-expires: 2026-03-26T08:42:09.059Z --> on Mar 26, 2026, 8:42 AM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, id: 23531986842, workflow_id: code-simplifier, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23531986842 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->