### PR TITLE
test: extend cache-budget-check tests (Groups 7-9: warn zone, both-over, status strings)

### DIFF
--- a/tests/test-build-cache-budget-check.sh
+++ b/tests/test-build-cache-budget-check.sh
@@ -173,4 +173,77 @@ assert_eq "GITHUB_STEP_SUMMARY has at least one numeric compressed-size cell" \
     "yes" "${compressed_value_found}"
 
 # ---------------------------------------------------------------------------
+# Group 7: build-native/target-libs exceeds warn threshold but not fail — should exit 0
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 7: target-libs in warn zone ==="
+
+# warn < 512 KiB (0.0003 GB ≈ 315 KiB), fail > 512 KiB (0.001 GB ≈ 1 MiB).
+assert_zero_exit "exits 0 when target-libs is in warn zone (above warn, below fail)" \
+    run_check "${_TMPDIR}" \
+        INSTALL_NATIVE_MAX_GB=0.01 \
+        INSTALL_NATIVE_WARN_GB=0.005 \
+        TARGET_LIBS_MAX_GB=0.001 \
+        TARGET_LIBS_WARN_GB=0.0003
+
+# ---------------------------------------------------------------------------
+# Group 8: Both directories exceed fail threshold — should exit non-zero
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 8: Both directories over fail threshold ==="
+
+# 0.0001 GB ≈ 104 KiB — both test directories (1 MiB and 512 KiB) exceed this.
+assert_nonzero_exit "exits non-zero when both directories exceed fail threshold" \
+    run_check "${_TMPDIR}" \
+        INSTALL_NATIVE_MAX_GB=0.0001 \
+        INSTALL_NATIVE_WARN_GB=0.00005 \
+        TARGET_LIBS_MAX_GB=0.0001 \
+        TARGET_LIBS_WARN_GB=0.00005
+
+# ---------------------------------------------------------------------------
+# Group 9: Output report contains expected status strings
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 9: Output status strings ==="
+
+# Both dirs within budget → both status cells should read "OK".
+_report_ok=$(run_check "${_TMPDIR}" \
+    INSTALL_NATIVE_MAX_GB=0.01 \
+    INSTALL_NATIVE_WARN_GB=0.005 \
+    TARGET_LIBS_MAX_GB=0.01 \
+    TARGET_LIBS_WARN_GB=0.005 2>/dev/null) || true
+assert_contains "output contains '| OK |' when directory is within budget" \
+    "${_report_ok}" "| OK |"
+
+# install-native in warn zone → install-native status cell should read "WARNING".
+_report_warn=$(run_check "${_TMPDIR}" \
+    INSTALL_NATIVE_MAX_GB=0.002 \
+    INSTALL_NATIVE_WARN_GB=0.0005 \
+    TARGET_LIBS_MAX_GB=0.01 \
+    TARGET_LIBS_WARN_GB=0.005 2>/dev/null) || true
+assert_contains "output contains '| WARNING |' when directory is in warn zone" \
+    "${_report_warn}" "| WARNING |"
+
+# install-native exceeds fail threshold → install-native status cell should read "OVER BUDGET".
+_report_over=$(run_check "${_TMPDIR}" \
+    INSTALL_NATIVE_MAX_GB=0.0001 \
+    INSTALL_NATIVE_WARN_GB=0.00005 \
+    TARGET_LIBS_MAX_GB=0.01 \
+    TARGET_LIBS_WARN_GB=0.005 2>/dev/null) || true
+assert_contains "output contains '| OVER BUDGET |' when directory exceeds fail threshold" \
+    "${_report_over}" "| OVER BUDGET |"
+
+# Missing directories → status cells should read "not found".
+_report_missing=$(run_check "${_EMPTY_TMPDIR}" \
+    INSTALL_NATIVE_MAX_GB=0.01 \
+    INSTALL_NATIVE_WARN_GB=0.005 \
+    TARGET_LIBS_MAX_GB=0.01 \
+    TARGET_LIBS_WARN_GB=0.005 2>/dev/null) || true
+assert_contains "output contains 'not found' when directory does not exist" \
+    "${_report_missing}" "not found"
+
+# ---------------------------------------------------------------------------
 print_test_results

--- a/tests/test-build-cache-budget-check.sh
+++ b/tests/test-build-cache-budget-check.sh
@@ -215,8 +215,12 @@ _report_ok=$(run_check "${_TMPDIR}" \
     INSTALL_NATIVE_WARN_GB=0.005 \
     TARGET_LIBS_MAX_GB=0.01 \
     TARGET_LIBS_WARN_GB=0.005 2>/dev/null) || true
-assert_contains "output contains '| OK |' when directory is within budget" \
-    "${_report_ok}" "| OK |"
+_row_install_ok=$(printf '%s\n' "${_report_ok}" | grep "install-native")
+_row_target_ok=$(printf '%s\n' "${_report_ok}" | grep "target-libs")
+assert_contains "output marks install-native as OK when within budget" \
+    "${_row_install_ok}" "| OK |"
+assert_contains "output marks build-native/target-libs as OK when within budget" \
+    "${_row_target_ok}" "| OK |"
 
 # install-native in warn zone → install-native status cell should read "WARNING".
 _report_warn=$(run_check "${_TMPDIR}" \
@@ -242,8 +246,8 @@ _report_missing=$(run_check "${_EMPTY_TMPDIR}" \
     INSTALL_NATIVE_WARN_GB=0.005 \
     TARGET_LIBS_MAX_GB=0.01 \
     TARGET_LIBS_WARN_GB=0.005 2>/dev/null) || true
-assert_contains "output contains 'not found' when directory does not exist" \
-    "${_report_missing}" "not found"
+assert_contains "output contains '| not found |' when directory does not exist" \
+    "${_report_missing}" "| not found |"
 
 # ---------------------------------------------------------------------------
 print_test_results


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant.*

## Description

`build-cache-budget-check.sh` was missing three categories of test coverage:

1. **target-libs warning zone** — Group 4 tested install-native in the warn zone, but no test verified target-libs in the warn zone. The two directories are independently checked by `status_for()`, so a regression in the target-libs path would go undetected.

2. **Both directories over budget simultaneously** — Groups 2 and 3 each exceeded one threshold. The case where both exceed their fail threshold was never tested; this is the most severe real-world failure mode (cache far over budget during a build spike).

3. **Output status strings** — Only exit codes were asserted. The `status_for()` helper's output (`OK`, `WARNING`, `OVER BUDGET`, `not found`) and `print_report()` were only tested structurally (table heading present, non-empty). A regression silently changing a status label would pass all existing tests.

Three new groups were added to `tests/test-build-cache-budget-check.sh`, using the existing `run_check` helper and `assert_contains`/`assert_zero_exit`/`assert_nonzero_exit` helpers:

- **Group 7** — target-libs warn zone: thresholds set so 512 KiB is above warn but below fail → exits 0
- **Group 8** — both over budget: 104 KiB fail threshold → both 1 MiB and 512 KiB test files exceed it → exits non-zero
- **Group 9** — status strings: captures stdout in four scenarios (OK, WARNING, OVER BUDGET, not found) and asserts the expected literal string appears in the table

Following review feedback, the Group 9 assertions were tightened:

- **OK check**: Replaced the single `"| OK |"` substring check (which only verified OK appeared somewhere in the report) with two per-row assertions. Each directory's row is extracted with `grep` before asserting `| OK |`, so a regression affecting only one row is caught individually.
- **"not found" check**: Changed needle from `"not found"` to `"| not found |"` to specifically match the Status column cell, preventing a false pass from the Size column's `(not found)` value.

All new tests reuse the same mock directories already created in the shared setup block. No new fixtures, no new dependencies.

## Testing

All 18 bash tests in `test-build-cache-budget-check.sh` pass (up from 11 before Groups 7–9 were added; the OK check now produces two assertions instead of one):

```
tests/test-build-cache-budget-check.sh: Results: 18 passed, 0 failed
```

Full suite:

```
tests/test-build-cache-budget-check.sh: Results: 18 passed, 0 failed
tests/test-build-common.sh: Results: 77 passed, 0 failed
tests/test-build-stage-scripts.sh: Results: 23 passed, 0 failed
tests/test-build-toolchain-args.sh: Results: 87 passed, 0 failed
tests/test-build-toolchain-cache-keys.sh: Results: 19 passed, 0 failed
tests/test-pre-cache-clean.sh: Results: 34 passed, 0 failed
tests/test-strip-binary.sh: Results: 13 passed, 0 failed
tests/test-measure-cache-compressed-size.sh: Results: 8 passed, 0 failed
tests/test-merge-gcc-final.sh: Results: 26 passed, 0 failed
```

```bash
bash tests/test-build-cache-budget-check.sh
```

## Checklist

- [ ] The PR title follows the Conventional Commits format (see note below)
- [ ] Changes are documented where appropriate

---

> [!IMPORTANT]
> **PR title must follow [Conventional Commits](https://www.conventionalcommits.org/) format.**
>
> PRs are squashed into the target branch using the **PR title** as the commit message.
> The PR title must therefore conform to commitlint requirements:
>
> ```
> <type>[(optional scope)][!]: <description>
> ```
>
> Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`, `perf`, `style`, `revert`
>
> [!NOTE]
> description **must not** start with uppercase letter
>
> Examples: `feat: add ARMv8-M support`, `fix: correct stack calculation`, `docs: update build instructions`
>
> Individual commits **within** the PR do **not** need to follow this format.

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.