### PR TITLE
test: add unit tests for build-toolchain.sh --skip_stages validation

### DIFF
--- a/.github/workflows/shell-unit-tests.yml
+++ b/.github/workflows/shell-unit-tests.yml
@@ -71,6 +71,7 @@ jobs:
           bash tests/test-build-common.sh
           bash tests/test-build-stage-action.sh
           bash tests/test-build-stage-scripts.sh
+          bash tests/test-build-toolchain.sh
           bash tests/test-build-toolchain-args.sh
           bash tests/test-build-toolchain-cache-keys.sh
           bash tests/test-measure-cache-compressed-size.sh

--- a/tests/test-build-toolchain.sh
+++ b/tests/test-build-toolchain.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Unit tests for build-toolchain.sh --skip_stages validation.
+#
+# Run with: bash tests/test-build-toolchain.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/build-toolchain.sh"
+
+# shellcheck source=tests/test-helpers.sh
+. "$SCRIPT_DIR/test-helpers.sh"
+
+# Flags that suppress all real build work so tests focus on the validation
+# block at the top of the script.
+SKIP_ALL=("--skip_steps=native,mingw,package_sources,md5_checksum,package_bins,manual")
+
+# ---------------------------------------------------------------------------
+# Test group 1: All seven valid stage names → exit 0
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 1: Valid stage names accepted ==="
+
+assert_zero_exit "binutils: valid stage name accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutils
+
+assert_zero_exit "gcc-first: valid stage name accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=gcc-first
+
+assert_zero_exit "newlib: valid stage name accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=newlib
+
+assert_zero_exit "newlib-nano: valid stage name accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=newlib-nano
+
+assert_zero_exit "gcc-final: valid stage name accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=gcc-final
+
+assert_zero_exit "gcc-size-libstdcxx: valid stage name accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=gcc-size-libstdcxx
+
+assert_zero_exit "gdb: valid stage name accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=gdb
+
+# ---------------------------------------------------------------------------
+# Test group 2: Invalid/typo stage names → exit 1 + error message on stderr
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 2: Invalid stage names rejected ==="
+
+assert_nonzero_exit "binutis (typo): exits non-zero" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutis
+
+_err2a=$(bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutis 2>&1 || true)
+assert_contains "binutis (typo): error message names the unknown stage" \
+    "$_err2a" "Unknown build stage: binutis"
+
+assert_nonzero_exit "nosuchthing: exits non-zero" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=nosuchthing
+
+_err2b=$(bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=nosuchthing 2>&1 || true)
+assert_contains "nosuchthing: error message names the unknown stage" \
+    "$_err2b" "Unknown build stage: nosuchthing"
+
+assert_nonzero_exit "wrong capitalisation (Binutils): exits non-zero" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=Binutils
+
+assert_nonzero_exit "prefix only (gcc): exits non-zero" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=gcc
+
+# ---------------------------------------------------------------------------
+# Test group 3: Multiple valid stages together → exit 0
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 3: Multiple valid stages accepted ==="
+
+assert_zero_exit "binutils,gcc-first: two valid stages accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutils,gcc-first
+
+assert_zero_exit "all seven stages: all valid stages together accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" \
+    --skip_stages=binutils,gcc-first,newlib,newlib-nano,gcc-final,gcc-size-libstdcxx,gdb
+
+# ---------------------------------------------------------------------------
+# Test group 4: Mix of valid and invalid stages → exit 1
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 4: Mixed valid and invalid stages rejected ==="
+
+assert_nonzero_exit "binutils,binutis (valid+invalid): exits non-zero" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutils,binutis
+
+_err4a=$(bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutils,binutis 2>&1 || true)
+assert_contains "valid+invalid mix: error message names the invalid stage" \
+    "$_err4a" "Unknown build stage: binutis"
+
+assert_nonzero_exit "binutis,binutils (invalid+valid): exits non-zero" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutis,binutils
+
+print_test_results

--- a/tests/test-build-toolchain.sh
+++ b/tests/test-build-toolchain.sh
@@ -45,31 +45,27 @@ assert_zero_exit "gdb: valid stage name accepted" \
     bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=gdb
 
 # ---------------------------------------------------------------------------
-# Test group 2: Invalid/typo stage names → exit 1 + error message on stderr
+# Test group 2: Invalid/typo stage names → exit 1 + error message
 # ---------------------------------------------------------------------------
 
 echo ""
 echo "=== Group 2: Invalid stage names rejected ==="
 
-assert_nonzero_exit "binutis (typo): exits non-zero" \
-    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutis
-
-_err2a=$(bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutis 2>&1 || true)
+_status=0; _out=$(bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutis 2>&1) || _status=$?
+assert_eq "binutis (typo): exits with status 1" "1" "$_status"
 assert_contains "binutis (typo): error message names the unknown stage" \
-    "$_err2a" "Unknown build stage: binutis"
+    "$_out" "Unknown build stage: binutis"
 
-assert_nonzero_exit "nosuchthing: exits non-zero" \
-    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=nosuchthing
-
-_err2b=$(bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=nosuchthing 2>&1 || true)
+_status=0; _out=$(bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=nosuchthing 2>&1) || _status=$?
+assert_eq "nosuchthing: exits with status 1" "1" "$_status"
 assert_contains "nosuchthing: error message names the unknown stage" \
-    "$_err2b" "Unknown build stage: nosuchthing"
+    "$_out" "Unknown build stage: nosuchthing"
 
-assert_nonzero_exit "wrong capitalisation (Binutils): exits non-zero" \
-    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=Binutils
+_status=0; _out=$(bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=Binutils 2>&1) || _status=$?
+assert_eq "wrong capitalisation (Binutils): exits with status 1" "1" "$_status"
 
-assert_nonzero_exit "prefix only (gcc): exits non-zero" \
-    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=gcc
+_status=0; _out=$(bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=gcc 2>&1) || _status=$?
+assert_eq "prefix only (gcc): exits with status 1" "1" "$_status"
 
 # ---------------------------------------------------------------------------
 # Test group 3: Multiple valid stages together → exit 0
@@ -92,14 +88,12 @@ assert_zero_exit "all seven stages: all valid stages together accepted" \
 echo ""
 echo "=== Group 4: Mixed valid and invalid stages rejected ==="
 
-assert_nonzero_exit "binutils,binutis (valid+invalid): exits non-zero" \
-    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutils,binutis
-
-_err4a=$(bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutils,binutis 2>&1 || true)
+_status=0; _out=$(bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutils,binutis 2>&1) || _status=$?
+assert_eq "binutils,binutis (valid+invalid): exits with status 1" "1" "$_status"
 assert_contains "valid+invalid mix: error message names the invalid stage" \
-    "$_err4a" "Unknown build stage: binutis"
+    "$_out" "Unknown build stage: binutis"
 
-assert_nonzero_exit "binutis,binutils (invalid+valid): exits non-zero" \
-    bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutis,binutils
+_status=0; _out=$(bash "$SCRIPT" "${SKIP_ALL[@]}" --skip_stages=binutis,binutils 2>&1) || _status=$?
+assert_eq "binutis,binutils (invalid+valid): exits with status 1" "1" "$_status"
 
 print_test_results


### PR DESCRIPTION
## Description

`build-toolchain.sh` contains a validation loop (lines 62–74) that rejects unknown `--skip_stages` values (e.g. typos like `binutis` instead of `binutils`) and exits with an error. This logic was previously untested — a regression could silently break the stage-skipping feature used in cached CI builds.

The 18 tests cover all seven valid stage names, unknown/typo stage names, comma-separated combinations, and error message content.

Each test invokes `bash build-toolchain.sh` with:
```
--skip_steps=native,mingw,package_sources,md5_checksum,package_bins,manual
```
to suppress all real build work. The validation loop runs unconditionally before any build step, so it is reachable even when all real work is skipped.

| Group | What is tested | Tests |
|-------|---------------|-------|
| 1 | All 7 valid stage names accepted → exit 0 | 7 |
| 2 | Unknown stage name rejected → exit 1 + error message | 6 |
| 3 | Multiple valid stages together → exit 0 | 2 |
| 4 | Mix of valid + invalid stages → exit 1 | 3 |

**Total: 18 assertions.**

### Test implementation details

- Each failing case captures stdout and stderr in a single invocation (`_out=$(... 2>&1) || _status=$?`), avoiding duplicate command runs and suppressing the verbose `_toolchain_usage` output from test output.
- Exit status is asserted exactly as `1` (using `assert_eq`) rather than merely non-zero, matching the `exit 1` in the script.
- `tests/test-build-toolchain.sh` is added to the hardcoded run list in `.github/workflows/shell-unit-tests.yml` so the tests execute in CI on every relevant change.

## Testing

- All 18 assertions pass locally (`Results: 18 passed, 0 failed`).
- `bash tests/test-build-toolchain.sh` can be run standalone at any time.

## Checklist

- [x] The PR title follows the Conventional Commits format (see note below)
- [x] Changes are documented where appropriate