### PR TITLE
test: add assert_not_contains helper and strengthen negative assertions

### DIFF
--- a/tests/test-entrypoint.sh
+++ b/tests/test-entrypoint.sh
@@ -92,6 +92,9 @@ true > "$_CMAKE_LOG"
 assert_eq "explicit BUILD_DIR: exit status 0" "0" \
     "$(exit_status_of "$_SRC3" "$_BUILD3")"
 
+assert_not_contains "explicit BUILD_DIR: no error in stderr" \
+    "$(stderr_of "$_SRC3" "$_BUILD3")" "Error"
+
 _LOG3=$(cat "$_CMAKE_LOG")
 assert_contains "explicit BUILD_DIR: cmake configure uses -B BUILD_DIR" \
     "$_LOG3" "$_BUILD3"
@@ -113,6 +116,9 @@ touch "$_SRC4/arm-none-eabi-gcc.cmake"
 true > "$_CMAKE_LOG"
 assert_eq "default BUILD_DIR: exit status 0" "0" \
     "$(exit_status_of "$_SRC4")"
+
+assert_not_contains "default BUILD_DIR: no error in stderr" \
+    "$(stderr_of "$_SRC4")" "Error"
 
 _LOG4=$(cat "$_CMAKE_LOG")
 assert_contains "default BUILD_DIR: cmake uses SOURCE_DIR/build" \

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -77,6 +77,19 @@ assert_contains() {
     fi
 }
 
+assert_not_contains() {
+    local desc="$1" haystack="$2" needle="$3"
+    if printf '%s\n' "${haystack}" | grep -Fq -- "${needle}"; then
+        _FAIL=$((_FAIL + 1))
+        echo "  FAIL: $desc"
+        echo "        expected NOT to contain: [${needle}]"
+        echo "        in:                      [${haystack}]"
+    else
+        _PASS=$((_PASS + 1))
+        echo "  PASS: $desc"
+    fi
+}
+
 assert_exit_status() {
     local desc="$1" expected_status="$2"
     if [ $# -lt 3 ]; then

--- a/tests/test-pre-cache-clean.sh
+++ b/tests/test-pre-cache-clean.sh
@@ -258,6 +258,7 @@ echo "fake-gcc" > "$_ROOT9/bin/arm-none-eabi-gcc"
 
 _OUTPUT9=$(bash "$SCRIPT" "$_ROOT9" 2>&1)
 assert_contains "safety check passed message present" "$_OUTPUT9" "Safety check passed"
+assert_not_contains "safety check passed: no FAILED message emitted" "$_OUTPUT9" "Safety check FAILED"
 
 # ---------------------------------------------------------------------------
 # Test group 10: Safety check silent when arm-none-eabi-gcc was never present
@@ -273,8 +274,7 @@ echo "fake-ld" > "$_ROOT10/bin/arm-none-eabi-ld"
 _root10_exit=0
 _OUTPUT10=$(bash "$SCRIPT" "$_ROOT10" 2>&1) || _root10_exit=$?
 assert_eq "no gcc before: script exits 0" "0" "$_root10_exit"
-assert_eq "no safety-check-passed message when gcc absent" "" \
-    "$(echo "$_OUTPUT10" | grep -F 'Safety check' || true)"
+assert_not_contains "no safety-check message when gcc absent before cleanup" "$_OUTPUT10" "Safety check"
 
 # ---------------------------------------------------------------------------
 # Test group 11: Safety check fails when arm-none-eabi-gcc was present before


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant focused on improving tests.*

## Goal and Rationale

`tests/test-helpers.sh` had `assert_contains` but no complement for negative assertions. Tests that wanted to verify output did **not** contain something either used a manual `grep -F ... || true` pattern with `assert_eq`, or simply didn't assert the absence at all.

This PR adds `assert_not_contains` and uses it to close two specific gaps:

1. **test-pre-cache-clean.sh group 9** — the safety-check-passed path asserted the "passed" message was present, but didn't verify the "FAILED" message was absent. A bug that emitted *both* messages would have gone undetected.
2. **test-pre-cache-clean.sh group 10** — the "gcc absent before cleanup" path used a manual `grep -F ... || true` piped into `assert_eq ""`, which is less readable and doesn't follow the helper pattern.
3. **test-entrypoint.sh groups 3 & 4** — happy-path invocations now assert no `Error` appears in stderr, catching any unexpected error output on success paths.

## Approach

- Added `assert_not_contains(desc, haystack, needle)` to `tests/test-helpers.sh` immediately after `assert_contains`, with consistent failure output format.
- Applied it in three places across two test files.

## Coverage Impact

| Metric | Before | After |
|--------|--------|-------|
| Bash tests (total) | 334 | 337 |
| `test-pre-cache-clean.sh` | 34 | 35 |
| `test-entrypoint.sh` | 11 | 13 |

## Trade-offs

- `assert_not_contains` calls entrypoint a second time in groups 3 & 4 (once for exit status, once to capture stderr). This is acceptable because the mock `cmake` is fast and stateless.
- No changes to CI workflow files — the new helper is picked up automatically by existing `shell-unit-tests.yml` runs.

## Reproducibility

```bash
bash tests/test-pre-cache-clean.sh
bash tests/test-entrypoint.sh
# Full test suite:
bash tests/test-build-cache-budget-check.sh && bash tests/test-build-common.sh && \
  bash tests/test-build-stage-scripts.sh && bash tests/test-build-toolchain-args.sh && \
  bash tests/test-build-toolchain-cache-keys.sh && bash tests/test-build-toolchain.sh && \
  bash tests/test-entrypoint.sh && bash tests/test-measure-cache-compressed-size.sh && \
  bash tests/test-merge-gcc-final.sh && bash tests/test-pre-cache-clean.sh && \
  bash tests/test-strip-binary.sh
```

## Test Status

✅ All 337 bash tests pass. `shellcheck` passes on modified files with `--severity=info`.




> Generated by [Daily Test Improver](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/25110228222/agentic_workflow) · ● 6M · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, model: auto, id: 25110228222, workflow_id: daily-test-improver, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/25110228222 -->

<!-- gh-aw-workflow-id: daily-test-improver -->