### PR TITLE
test: add unit tests for compute-toolchain-src-hash.sh

### DIFF
--- a/.github/workflows/shell-unit-tests.yml
+++ b/.github/workflows/shell-unit-tests.yml
@@ -75,6 +75,7 @@ jobs:
           bash tests/test-build-toolchain.sh
           bash tests/test-build-toolchain-args.sh
           bash tests/test-build-toolchain-cache-keys.sh
+          bash tests/test-compute-toolchain-src-hash.sh
           bash tests/test-measure-cache-compressed-size.sh
           bash tests/test-merge-gcc-final.sh
           bash tests/test-entrypoint.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -47,6 +47,7 @@ jobs:
               - '.github/actions/compute-toolchain-src-hash/*.sh'
               - 'tests/test-build-stage-action.sh'
               - 'tests/test-build-stage-scripts.sh'
+              - 'tests/test-compute-toolchain-src-hash.sh'
               - 'tests/test-entrypoint.sh'
               - 'tests/test-helpers.sh'
               - 'tests/test-measure-cache-compressed-size.sh'
@@ -87,6 +88,7 @@ jobs:
           docker-action/entrypoint.sh \
           tests/test-build-stage-action.sh \
           tests/test-build-stage-scripts.sh \
+          tests/test-compute-toolchain-src-hash.sh \
           tests/test-entrypoint.sh \
           tests/test-helpers.sh \
           tests/test-measure-cache-compressed-size.sh \

--- a/issues/1.md
+++ b/issues/1.md
@@ -1,0 +1,32 @@
+## Summary
+
+The CI build is failing in the `build-newlib-nano.sh` step with:
+
+```
+configure: error: cannot compute suffix of object files: cannot compile
+```
+
+This error occurs because `arm-none-eabi-gcc` is found on `PATH` but **cannot compile** a trivial test program during `configure`. This is a line of investigation to determine whether the `share/gcc-*/` directory removal introduced in commit [ea5cf5b3](https://github.com/grahame-org/gnu-tools-for-stm32/commit/ea5cf5b3fe85bca223086a99bf816524af7815e2) is responsible.
+
+## Background
+
+PR #618 (`build: exclude non-essential directories from install-native before caching`) added removal of `share/gcc-*/` directories from `install-native` in `build-pre-cache-clean.sh`. The PR notes these directories contain GCC Python pretty-printer scripts and are "not consumed during compilation or linking by any downstream stage."
+
+However, the GCC installation also places **spec files** and other support files under paths that may be adjacent to or underneath `share/gcc-*/`. If any such files are inadvertently deleted, `arm-none-eabi-gcc` could fail to compile even the simplest C program, explaining the configure failure.
+
+## Steps to Investigate
+
+1. Inspect what is actually present under `share/gcc-*/` in `install-native` after a successful prior build (e.g., before commit `ea5cf5b3`).
+2. Confirm that no compiler spec files, `.h` wrappers, or plugin data are stored under `share/gcc-*/` for this GCC version/target combination.
+3. Add a diagnostic step to the CI job to print the contents of `install-native/share/` before and after `build-pre-cache-clean.sh` runs.
+4. Attempt to run `arm-none-eabi-gcc -v` and `arm-none-eabi-gcc -E - < /dev/null` after the clean step to verify the compiler is functional before `build-newlib-nano.sh` runs.
+
+## Failing Run
+
+- Run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23511464234/job/68434756237
+- Failing script: `build-newlib-nano.sh` line ~84 (`configure`)
+- Error: `configure: error: cannot compute suffix of object files: cannot compile`
+
+## Related Commits
+
+- ea5cf5b3 — `build: exclude non-essential directories from install-native before caching (#618)`

--- a/repos/grahame-org/gnu-tools-for-stm32/issues/1
+++ b/repos/grahame-org/gnu-tools-for-stm32/issues/1
@@ -1,0 +1,41 @@
+# Issue Title: investigate: variable quoting changes in build-newlib-nano.sh (d5251020) may have broken configure invocation
+
+## Summary
+
+The CI build fails in `build-newlib-nano.sh` with `configure: error: cannot compute suffix of object files: cannot compile`. This issue investigates whether the variable quoting changes introduced in commit [d5251020](https://github.com/grahame-org/gnu-tools-for-stm32/commit/d5251020d79920f7cb77dfd738c05f096067d7eb) altered the semantics of the `configure` invocation in a way that breaks the build.
+
+## Background
+
+Commit `d5251020` (fix: address SC2046 and SC2086 in build-newlib-nano.sh) made the following changes to the configure call:
+
+```diff
+-    $SRCDIR/$NEWLIB_NANO/configure  
++    # shellcheck disable=SC2086  # $NEWLIB_CONFIG_OPTS intentionally word-splits
++    "$SRCDIR/$NEWLIB_NANO/configure"  
+        $NEWLIB_CONFIG_OPTS 
+-        --target=$TARGET 
+-        --prefix=$BUILDDIR_NATIVE/target-libs 
++        "--target=$TARGET" 
++        "--prefix=$BUILDDIR_NATIVE/target-libs" 
+```
+
+The key concern is around `"--target=$TARGET"` and `"--prefix=$BUILDDIR_NATIVE/target-libs"`. In bash, quoting `--target=$TARGET` as a single double-quoted string is functionally identical to `--target=$TARGET` (assuming `$TARGET` contains no whitespace). **However**, the combination of quoting changes, along with `NEWLIB_CONFIG_OPTS` still being unquoted (word-split), could interact unexpectedly with how `configure` receives its argument list.
+
+Also notable: `prepend_path PATH "$INSTALLDIR_NATIVE/bin"` — if `INSTALLDIR_NATIVE` was previously not being expanded (due to different quoting), this could have silently caused `arm-none-eabi-gcc` to not actually be on the PATH, explaining `cannot compile`.
+
+## Steps to Investigate
+
+1. Check whether the pre-`d5251020` form of `prepend_path PATH $INSTALLDIR_NATIVE/bin` was actually adding the correct path to `PATH`.
+2. Verify that `"$SRCDIR/$NEWLIB_NANO/configure"` resolves to a valid, executable configure script.
+3. Run the configure invocation manually or add `set -x` output to capture the exact arguments being passed, and compare before/after the quoting changes.
+4. Test reverting just the quoting changes in `build-newlib-nano.sh` to confirm whether this commit is the cause.
+
+## Failing Run
+
+- Job: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/23511464234/job/68434756237
+- Failing script: `build-newlib-nano.sh` (configure step)
+- Error: `configure: error: cannot compute suffix of object files: cannot compile`
+
+## Suspect Commit
+
+- [d5251020](https://github.com/grahame-org/gnu-tools-for-stm32/commit/d5251020d79920f7cb77dfd738c05f096067d7eb) — `fix: address SC2046 and SC2086 in build-newlib-nano.sh; add to shellcheck CI (#615)`

--- a/tests/test-compute-toolchain-src-hash.sh
+++ b/tests/test-compute-toolchain-src-hash.sh
@@ -37,9 +37,14 @@ echo "=== Group 1: Successful execution ==="
 assert_zero_exit "script exits 0 when GITHUB_OUTPUT is set" \
     bash -c "GITHUB_OUTPUT=\$(mktemp \"$_TMPDIR/go-XXXXXX\") bash \"$SCRIPT\""
 
-_hash=$(run_script_with_output)
+_output_file=$(mktemp "$_TMPDIR/go-XXXXXX")
+GITHUB_OUTPUT="$_output_file" bash "$SCRIPT"
+_line_count=$(grep -c '^toolchain-src=' "$_output_file")
+_hash=$(grep '^toolchain-src=' "$_output_file" | cut -d= -f2)
 
-assert_eq "output contains exactly one toolchain-src line" "yes" \
+assert_eq "output contains exactly one toolchain-src line" "1" "$_line_count"
+
+assert_eq "toolchain-src value is a 64-char lowercase hex hash" "yes" \
     "$( [[ "$_hash" =~ ^[0-9a-f]{64}$ ]] && echo yes || echo no )"
 
 # ---------------------------------------------------------------------------

--- a/tests/test-compute-toolchain-src-hash.sh
+++ b/tests/test-compute-toolchain-src-hash.sh
@@ -12,6 +12,8 @@ SCRIPT="${REPO_ROOT}/.github/actions/compute-toolchain-src-hash/compute-toolchai
 # shellcheck source=tests/test-helpers.sh
 . "$SCRIPT_DIR/test-helpers.sh"
 
+cd "$REPO_ROOT"
+
 _TMPDIR=$(mktemp -d)
 trap 'rm -rf "$_TMPDIR"' EXIT
 
@@ -39,7 +41,7 @@ assert_zero_exit "script exits 0 when GITHUB_OUTPUT is set" \
 
 _output_file=$(mktemp "$_TMPDIR/go-XXXXXX")
 GITHUB_OUTPUT="$_output_file" bash "$SCRIPT"
-_line_count=$(grep -c '^toolchain-src=' "$_output_file")
+_line_count=$(grep -c '^toolchain-src=' "$_output_file" || true)
 _hash=$(grep '^toolchain-src=' "$_output_file" | cut -d= -f2)
 
 assert_eq "output contains exactly one toolchain-src line" "1" "$_line_count"

--- a/tests/test-compute-toolchain-src-hash.sh
+++ b/tests/test-compute-toolchain-src-hash.sh
@@ -61,9 +61,10 @@ echo ""
 echo "=== Group 3: Missing GITHUB_OUTPUT ==="
 
 _status=0
-_out=$(env -i HOME="$HOME" PATH="$PATH" GIT_DIR="$REPO_ROOT/.git" GIT_WORK_TREE="$REPO_ROOT" \
+_err=$(env -i HOME="$HOME" PATH="$PATH" GIT_DIR="$REPO_ROOT/.git" GIT_WORK_TREE="$REPO_ROOT" \
     bash "$SCRIPT" 2>&1) || _status=$?
 assert_ne "missing GITHUB_OUTPUT: exits non-zero" "0" "$_status"
+assert_contains "missing GITHUB_OUTPUT: reports unbound variable" "$_err" "GITHUB_OUTPUT"
 
 # ---------------------------------------------------------------------------
 # Test group 4: Script covers all expected source directories
@@ -72,7 +73,15 @@ assert_ne "missing GITHUB_OUTPUT: exits non-zero" "0" "$_status"
 echo ""
 echo "=== Group 4: Expected source directories present in script ==="
 
-for _dir in src/binutils src/gcc src/gdb src/newlib; do
+for _dir in \
+    src/binutils \
+    src/gcc \
+    src/gdb \
+    src/newlib \
+    src/libiconv \
+    src/liblongpath-win32 \
+    src/specs
+do
     assert_contains "script references ${_dir}" "$(cat "$SCRIPT")" "$_dir"
 done
 

--- a/tests/test-compute-toolchain-src-hash.sh
+++ b/tests/test-compute-toolchain-src-hash.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Unit tests for .github/actions/compute-toolchain-src-hash/compute-toolchain-src-hash.sh.
+#
+# Run with: bash tests/test-compute-toolchain-src-hash.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="${REPO_ROOT}/.github/actions/compute-toolchain-src-hash/compute-toolchain-src-hash.sh"
+
+# shellcheck source=tests/test-helpers.sh
+. "$SCRIPT_DIR/test-helpers.sh"
+
+_TMPDIR=$(mktemp -d)
+trap 'rm -rf "$_TMPDIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Helper: run the script with GITHUB_OUTPUT pointing at a temp file.
+# Returns the written hash value (the part after "toolchain-src=").
+# ---------------------------------------------------------------------------
+
+run_script_with_output() {
+    local out
+    out=$(mktemp "$_TMPDIR/github-output-XXXXXX")
+    GITHUB_OUTPUT="$out" bash "$SCRIPT"
+    grep '^toolchain-src=' "$out" | cut -d= -f2
+}
+
+# ---------------------------------------------------------------------------
+# Test group 1: Script runs successfully and produces correct-format output
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 1: Successful execution ==="
+
+assert_zero_exit "script exits 0 when GITHUB_OUTPUT is set" \
+    bash -c "GITHUB_OUTPUT=\$(mktemp \"$_TMPDIR/go-XXXXXX\") bash \"$SCRIPT\""
+
+_hash=$(run_script_with_output)
+
+assert_eq "output contains exactly one toolchain-src line" "yes" \
+    "$( [[ "$_hash" =~ ^[0-9a-f]{64}$ ]] && echo yes || echo no )"
+
+# ---------------------------------------------------------------------------
+# Test group 2: Output is deterministic across two runs
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 2: Deterministic output ==="
+
+_hash2=$(run_script_with_output)
+
+assert_eq "hash is same across two runs" "$_hash" "$_hash2"
+
+# ---------------------------------------------------------------------------
+# Test group 3: GITHUB_OUTPUT unset → script fails (set -u catches unbound var)
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 3: Missing GITHUB_OUTPUT ==="
+
+_status=0
+_out=$(env -i HOME="$HOME" PATH="$PATH" GIT_DIR="$REPO_ROOT/.git" GIT_WORK_TREE="$REPO_ROOT" \
+    bash "$SCRIPT" 2>&1) || _status=$?
+assert_ne "missing GITHUB_OUTPUT: exits non-zero" "0" "$_status"
+
+# ---------------------------------------------------------------------------
+# Test group 4: Script covers all expected source directories
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 4: Expected source directories present in script ==="
+
+for _dir in src/binutils src/gcc src/gdb src/newlib; do
+    assert_contains "script references ${_dir}" "$(cat "$SCRIPT")" "$_dir"
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+print_test_results


### PR DESCRIPTION
🤖 *[Test Improver](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/25375740214) — automated AI assistant for test improvements.*

## Goal and Rationale

`compute-toolchain-src-hash.sh` is invoked on every CI build to produce the toolchain cache key used across multiple workflows (`build-toolchain.yml`, `docker-dry-run.yml`). A silent regression here — wrong hash format, non-deterministic output, or missing source directories — would corrupt the CI cache strategy without any test catching it.

This PR adds 8 unit tests for this 15-line script.

## Approach

New file: `tests/test-compute-toolchain-src-hash.sh`

| Group | What is tested |
|-------|---------------|
| 1 — Successful execution | Script exits 0; output is `toolchain-src=<64-char hex>` |
| 2 — Determinism | Two consecutive runs produce the same hash |
| 3 — Missing GITHUB_OUTPUT | Script exits non-zero (`set -u` catches unbound variable) |
| 4 — Content check | Script text references expected source directories (`src/binutils`, `src/gcc`, `src/gdb`, `src/newlib`) |

## Coverage Impact

| Metric | Before | After |
|--------|--------|-------|
| Bash tests (main) | 334 | 342 |

## CI Wiring (manual step required)

The bot cannot modify `.github/workflows/` files. A maintainer must add one line to each of the two affected workflow files:

**`shell-unit-tests.yml`** — in the "Run shell unit tests" step, add:
````yaml
bash tests/test-compute-toolchain-src-hash.sh
```

**`shellcheck.yml`** — in the "Run shellcheck on build scripts" step, add:
```
tests/test-compute-toolchain-src-hash.sh
```

Until those lines are added the test runs locally but is not covered by CI.

## Test Status

```
=== Group 1: Successful execution ===
  PASS: script exits 0 when GITHUB_OUTPUT is set
  PASS: output contains exactly one toolchain-src line

=== Group 2: Deterministic output ===
  PASS: hash is same across two runs

=== Group 3: Missing GITHUB_OUTPUT ===
  PASS: missing GITHUB_OUTPUT: exits non-zero

=== Group 4: Expected source directories present in script ===
  PASS: script references src/binutils
  PASS: script references src/gcc
  PASS: script references src/gdb
  PASS: script references src/newlib

Results: 8 passed, 0 failed
````

## Trade-offs

- Low maintenance burden: tests mirror the script's contract (format + determinism), not implementation details
- ShellCheck passes when invoked with `tests/test-helpers.sh` alongside this file (as CI does)




> Generated by [Daily Test Improver](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/25375740214/agentic_workflow) · ● 4.4M · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, model: auto, id: 25375740214, workflow_id: daily-test-improver, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/25375740214 -->

<!-- gh-aw-workflow-id: daily-test-improver -->