### PR TITLE
test: add unit tests for build-gcc-size-libstdcxx.sh

### DIFF
--- a/tests/test-build-gcc-size-libstdcxx.sh
+++ b/tests/test-build-gcc-size-libstdcxx.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Unit tests for build-gcc-size-libstdcxx.sh argument validation and the
+# MULTILIB_LIST default-override logic.
+#
+# build-gcc-size-libstdcxx.sh narrows the default MULTILIB_LIST from
+# "--with-multilib-list=rmprofile,aprofile" (set by parse_toolchain_args) to
+# "--with-multilib-list=rmprofile" (Cortex-M only) when no explicit
+# --with-multilib-list=* flag is passed.  An explicit flag bypasses that
+# narrowing.
+#
+# Run with: bash tests/test-build-gcc-size-libstdcxx.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/build-gcc-size-libstdcxx.sh"
+
+# shellcheck source=tests/test-helpers.sh
+. "$SCRIPT_DIR/test-helpers.sh"
+
+# Flags that suppress all real build work so tests focus on argument parsing
+# and the MULTILIB_LIST override logic near the top of the script.
+SKIP_ALL=("--skip_steps=native,mingw,package_sources,md5_checksum,package_bins,manual")
+
+# ---------------------------------------------------------------------------
+# Test group 1: Accepted flag combinations → exit 0
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 1: Accepted flag combinations ==="
+
+assert_zero_exit "SKIP_ALL alone: exits cleanly" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}"
+
+assert_zero_exit "--build_type=native accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --build_type=native
+
+assert_zero_exit "--build_type=ppa accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --build_type=ppa
+
+assert_zero_exit "--with-multilib-list=rmprofile accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --with-multilib-list=rmprofile
+
+assert_zero_exit "--with-multilib-list=rmprofile,aprofile accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --with-multilib-list=rmprofile,aprofile
+
+assert_zero_exit "--with-multilib-list=aprofile accepted" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --with-multilib-list=aprofile
+
+# ---------------------------------------------------------------------------
+# Test group 2: Rejected arguments → non-zero exit
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 2: Rejected arguments ==="
+
+assert_nonzero_exit "unknown flag rejected" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --unknown-flag
+
+assert_nonzero_exit "--build_type=badtype rejected" \
+    bash "$SCRIPT" "${SKIP_ALL[@]}" --build_type=badtype
+
+# ---------------------------------------------------------------------------
+# Helper: run the script and return the last --with-multilib-list=VALUE seen
+# in the set -x trace written to stderr.
+# ---------------------------------------------------------------------------
+_last_multilib() {
+    bash "$SCRIPT" "${SKIP_ALL[@]}" "$@" 2>&1 | \
+        grep 'MULTILIB_LIST=--with-multilib-list=' | \
+        tail -1 | \
+        grep -o -- '--with-multilib-list=[^[:space:]]*'
+}
+
+# ---------------------------------------------------------------------------
+# Test group 3: MULTILIB_LIST default-override logic
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 3: MULTILIB_LIST default-override logic ==="
+
+multilib_val=$(_last_multilib)
+assert_eq "no --with-multilib-list flag: MULTILIB_LIST narrowed to rmprofile only" \
+    "--with-multilib-list=rmprofile" "$multilib_val"
+
+multilib_val=$(_last_multilib --with-multilib-list=rmprofile,aprofile)
+assert_eq "--with-multilib-list=rmprofile,aprofile explicit: override not applied" \
+    "--with-multilib-list=rmprofile,aprofile" "$multilib_val"
+
+multilib_val=$(_last_multilib --with-multilib-list=aprofile)
+assert_eq "--with-multilib-list=aprofile explicit: override not applied" \
+    "--with-multilib-list=aprofile" "$multilib_val"
+
+multilib_val=$(_last_multilib --with-multilib-list=rmprofile)
+assert_eq "--with-multilib-list=rmprofile explicit: last value is rmprofile" \
+    "--with-multilib-list=rmprofile" "$multilib_val"
+
+# ---------------------------------------------------------------------------
+print_test_results

--- a/tests/test-build-gcc-size-libstdcxx.sh
+++ b/tests/test-build-gcc-size-libstdcxx.sh
@@ -67,18 +67,26 @@ assert_nonzero_exit "--build_type=badtype rejected" \
 # Captures stdout+stderr and checks the exit status before processing output,
 # so a non-zero exit from the script is surfaced as a failure rather than
 # being masked by the pipeline.
+# The extraction pipeline uses || true so that a grep-no-match does not abort
+# the test script under set -e; an empty result causes assert_eq to report
+# a proper FAIL with the full trace shown for diagnosis.
 # ---------------------------------------------------------------------------
 _last_multilib() {
-    local output exit_status=0
+    local output exit_status=0 extracted
     output=$(bash "$SCRIPT" "${SKIP_ALL[@]}" "$@" 2>&1) || exit_status=$?
     if [ "$exit_status" -ne 0 ]; then
         echo "ERROR: $SCRIPT exited with status $exit_status" >&2
         return "$exit_status"
     fi
-    printf '%s\n' "$output" | \
+    extracted=$(printf '%s\n' "$output" | \
         grep 'MULTILIB_LIST=--with-multilib-list=' | \
         tail -1 | \
-        grep -o -- '--with-multilib-list=[^[:space:]]*'
+        grep -o -- '--with-multilib-list=[^[:space:]]*' || true)
+    if [ -z "$extracted" ]; then
+        echo "ERROR: no MULTILIB_LIST=--with-multilib-list= line found in trace; full output:" >&2
+        printf '%s\n' "$output" >&2
+    fi
+    printf '%s\n' "$extracted"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test-build-gcc-size-libstdcxx.sh
+++ b/tests/test-build-gcc-size-libstdcxx.sh
@@ -64,9 +64,18 @@ assert_nonzero_exit "--build_type=badtype rejected" \
 # ---------------------------------------------------------------------------
 # Helper: run the script and return the last --with-multilib-list=VALUE seen
 # in the set -x trace written to stderr.
+# Captures stdout+stderr and checks the exit status before processing output,
+# so a non-zero exit from the script is surfaced as a failure rather than
+# being masked by the pipeline.
 # ---------------------------------------------------------------------------
 _last_multilib() {
-    bash "$SCRIPT" "${SKIP_ALL[@]}" "$@" 2>&1 | \
+    local output exit_status=0
+    output=$(bash "$SCRIPT" "${SKIP_ALL[@]}" "$@" 2>&1) || exit_status=$?
+    if [ "$exit_status" -ne 0 ]; then
+        echo "ERROR: $SCRIPT exited with status $exit_status" >&2
+        return "$exit_status"
+    fi
+    printf '%s\n' "$output" | \
         grep 'MULTILIB_LIST=--with-multilib-list=' | \
         tail -1 | \
         grep -o -- '--with-multilib-list=[^[:space:]]*'


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant focused on improving tests for this repository.*

## Goal and Rationale

`build-gcc-size-libstdcxx.sh` contains a unique, non-trivial piece of logic that was previously untested: it narrows the default `MULTILIB_LIST` from `--with-multilib-list=rmprofile,aprofile` (the default set by `parse_toolchain_args`) down to `--with-multilib-list=rmprofile` (Cortex-M only) when no explicit `--with-multilib-list=*` flag is passed. An explicit flag bypasses this narrowing.

This behaviour is documented in a comment at lines 64–68 of the script but had no test coverage.

## Approach

12 tests across three groups:

1. **Accepted flag combinations** (6 tests): `SKIP_ALL` alone, `--build_type=native/ppa`, `--with-multilib-list=rmprofile/rmprofile,aprofile/aprofile` → all exit 0.
2. **Rejected arguments** (2 tests): unknown flag, invalid `--build_type` → non-zero exit.
3. **MULTILIB_LIST default-override logic** (4 tests): verifies the final `MULTILIB_LIST` assignment in the `set -x` trace:
   - No `--with-multilib-list=*` → final value is `--with-multilib-list=rmprofile` (override applied).
   - Explicit `--with-multilib-list=rmprofile,aprofile` → final value is `--with-multilib-list=rmprofile,aprofile` (override bypassed).
   - Explicit `--with-multilib-list=aprofile` → final value is `--with-multilib-list=aprofile` (override bypassed).
   - Explicit `--with-multilib-list=rmprofile` → final value is `--with-multilib-list=rmprofile`.

The `SKIP_ALL` flags (`--skip_steps=native,mingw,package_sources,md5_checksum,package_bins,manual`) suppress all real build work so tests complete quickly.

## Coverage Impact

| Metric | Before | After |
|--------|--------|-------|
| Bash tests (main) | 334 | +12 → 346 |
| `build-gcc-size-libstdcxx.sh` argument/override tests | 0 | 12 |

## ⚠️ CI Wiring — Maintainer Action Required

The bot lacks `workflows` permission and cannot push changes to `.github/workflows/`. To wire the new test file into CI, a maintainer needs to add one line to each of two workflow files:

**`.github/workflows/shell-unit-tests.yml`** — in the "Run shell unit tests" step, add:
````yaml
          bash tests/test-build-gcc-size-libstdcxx.sh
```

**`.github/workflows/shellcheck.yml`** — in the "Run shellcheck on build scripts" step, add:
```
          tests/test-build-gcc-size-libstdcxx.sh \
```

Also add `build-gcc-size-libstdcxx.sh` to the paths-filter in `shell-unit-tests.yml` if not already present (it should already trigger since `tests/**` is in the filter).

## Trade-offs

- Group 3 tests rely on `set -x` trace output in stderr to observe the `MULTILIB_LIST` variable assignment. This is slightly coupled to implementation internals, but is the only viable way to verify the variable's final value without modifying the production script. The trace format is stable across bash versions.

## Test Status

All 12 tests pass locally:
```
=== Group 1: Accepted flag combinations ===
  PASS: SKIP_ALL alone: exits cleanly
  PASS: --build_type=native accepted
  PASS: --build_type=ppa accepted
  PASS: --with-multilib-list=rmprofile accepted
  PASS: --with-multilib-list=rmprofile,aprofile accepted
  PASS: --with-multilib-list=aprofile accepted

=== Group 2: Rejected arguments ===
  PASS: unknown flag rejected
  PASS: --build_type=badtype rejected

=== Group 3: MULTILIB_LIST default-override logic ===
  PASS: no --with-multilib-list flag: MULTILIB_LIST narrowed to rmprofile only
  PASS: --with-multilib-list=rmprofile,aprofile explicit: override not applied
  PASS: --with-multilib-list=aprofile explicit: override not applied
  PASS: --with-multilib-list=rmprofile explicit: last value is rmprofile

Results: 12 passed, 0 failed
````

`shellcheck --severity=info` is clean (run with `-x` to follow source directives).

## Reproducibility

```bash
bash tests/test-build-gcc-size-libstdcxx.sh
```




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 1 item</summary>
>
> The following item were blocked because they don't meet the GitHub integrity level.
>
> - [#745](https://github.com/grahame-org/gnu-tools-for-stm32/pull/745) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Test Improver](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/25436938790/agentic_workflow) · ● 5M · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, model: auto, id: 25436938790, workflow_id: daily-test-improver, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/25436938790 -->

<!-- gh-aw-workflow-id: daily-test-improver -->