### PR TITLE
[code-simplifier] refactor: rename grep_stderr to grep_output and use printf pipe in assert_matches/assert_not_matches

### DIFF
--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -92,8 +92,8 @@ assert_not_contains() {
 
 assert_matches() {
     local desc="$1" haystack="$2" pattern="$3"
-    local grep_stderr grep_status=0
-    grep_stderr=$(grep -Eq -- "${pattern}" <<< "${haystack}" 2>&1) || grep_status=$?
+    local grep_output grep_status=0
+    grep_output=$(printf '%s\n' "${haystack}" | grep -Eq -- "${pattern}" 2>&1) || grep_status=$?
     if [ "${grep_status}" -eq 0 ]; then
         _PASS=$((_PASS + 1))
         echo "  PASS: $desc"
@@ -105,15 +105,15 @@ assert_matches() {
     else
         _FAIL=$((_FAIL + 1))
         echo "  FAIL: $desc"
-        echo "        grep error (status ${grep_status}): ${grep_stderr}"
+        echo "        grep error (status ${grep_status}): ${grep_output}"
         echo "        pattern: [${pattern}]"
     fi
 }
 
 assert_not_matches() {
     local desc="$1" haystack="$2" pattern="$3"
-    local grep_stderr grep_status=0
-    grep_stderr=$(grep -Eq -- "${pattern}" <<< "${haystack}" 2>&1) || grep_status=$?
+    local grep_output grep_status=0
+    grep_output=$(printf '%s\n' "${haystack}" | grep -Eq -- "${pattern}" 2>&1) || grep_status=$?
     if [ "${grep_status}" -eq 1 ]; then
         _PASS=$((_PASS + 1))
         echo "  PASS: $desc"
@@ -125,7 +125,7 @@ assert_not_matches() {
     else
         _FAIL=$((_FAIL + 1))
         echo "  FAIL: $desc"
-        echo "        grep error (status ${grep_status}): ${grep_stderr}"
+        echo "        grep error (status ${grep_status}): ${grep_output}"
         echo "        pattern: [${pattern}]"
     fi
 }


### PR DESCRIPTION
This PR simplifies the `assert_matches` and `assert_not_matches` helpers added in #798 to improve consistency and naming accuracy within `tests/test-helpers.sh`.

### Files Simplified

- `tests/test-helpers.sh` — two small fixes in the newly added `assert_matches`/`assert_not_matches` functions

### Improvements Made

#### 1. Accurate variable name: `grep_stderr` → `grep_output`

The variable captured `2>&1` output (stderr redirected into stdout, then captured by `$(...)`). Naming it `grep_stderr` was misleading because in shell, `$(cmd 2>&1)` captures stdout — which happens to contain the redirected stderr. `grep_output` accurately describes what is stored.

#### 2. Consistent input method: here-string `<<<` → `printf '%s\n' ... |`

The two new functions used a bash here-string:
```bash
grep -Eq -- "\$\{pattern}" <<< "\$\{haystack}"
```
while the existing `assert_contains` / `assert_not_contains` helpers use:
```bash
printf '%s\n' "\$\{haystack}" | grep -Fq -- "\$\{needle}"
```
Both are functionally equivalent (both append a trailing newline). Aligning to the `printf` pipe style removes the inconsistency and avoids a bash-specific construct where a POSIX-compatible alternative already exists in the same file.

### Changes Based On

- #798 — `test: add assert_matches/assert_not_matches regex helpers`

### Testing

- ✅ All 15 test suites pass (299 assertions total, 0 failures)
- ✅ `shellcheck tests/test-helpers.sh` — clean
- ✅ `bash -n tests/test-helpers.sh` — syntax valid
- ✅ No functional changes — behaviour is identical

### Review Focus

Please verify:
- Functionality is preserved
- `printf '%s\n' ... | grep -Eq` is equivalent to `grep -Eq <<< ...` for all inputs
- `grep_output` is a clearer name than `grep_stderr` for captured `2>&1` output

**References:** [§25989378607](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/25989378607)

---
*Automated by Code Simplifier Agent — analysing code from the last 24 hours*


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/25989378607/agentic_workflow) · ● 753.4K · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/github/gh-aw/blob/f5aa6a7699752651789e8c80c9d24f8e9fa31809/.github/workflows/code-simplifier.md), run
> ```
> gh aw add github/gh-aw/.github/workflows/code-simplifier.md@f5aa6a7699752651789e8c80c9d24f8e9fa31809
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-18T11:27:44.582Z --> on May 18, 2026, 11:27 AM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, model: auto, id: 25989378607, workflow_id: code-simplifier, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/25989378607 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->