### PR TITLE
[Test Improver] test: show command output in assert_zero_exit, assert_nonzero_exit, assert_exit_status on failure

### DIFF
--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -27,9 +27,11 @@ assert_nonzero_exit() {
         return
     fi
     shift
-    if "$@" 2>/dev/null; then
+    local _diag
+    if _diag=$("$@" 2>&1); then
         _FAIL=$((_FAIL + 1))
         echo "  FAIL: $desc (expected non-zero exit)"
+        [ -n "$_diag" ] && echo "        output: $_diag"
     else
         _PASS=$((_PASS + 1))
         echo "  PASS: $desc"
@@ -44,12 +46,15 @@ assert_zero_exit() {
         return
     fi
     shift
-    if "$@" 2>/dev/null; then
+    local _diag _status=0
+    _diag=$("$@" 2>&1) || _status=$?
+    if [ "$_status" -eq 0 ]; then
         _PASS=$((_PASS + 1))
         echo "  PASS: $desc"
     else
         _FAIL=$((_FAIL + 1))
-        echo "  FAIL: $desc (expected zero exit)"
+        echo "  FAIL: $desc (expected zero exit, got status $_status)"
+        [ -n "$_diag" ] && echo "        output: $_diag"
     fi
 }
 
@@ -138,8 +143,8 @@ assert_exit_status() {
         return
     fi
     shift 2
-    local actual_status=0
-    "$@" 2>/dev/null || actual_status=$?
+    local actual_status=0 _diag
+    _diag=$("$@" 2>&1) || actual_status=$?
     if [ "$actual_status" -eq "$expected_status" ]; then
         _PASS=$((_PASS + 1))
         echo "  PASS: $desc"
@@ -148,6 +153,7 @@ assert_exit_status() {
         echo "  FAIL: $desc"
         echo "        expected exit status: [$expected_status]"
         echo "        actual exit status:   [$actual_status]"
+        [ -n "$_diag" ] && echo "        output: $_diag"
     fi
 }
 


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant.*

## Goal and rationale

`assert_zero_exit`, `assert_nonzero_exit`, and `assert_exit_status` previously discarded all command output (`2>/dev/null`). When an assertion unexpectedly fails, the only visible clue was the exit code mismatch — no context about what the command actually printed. This made debugging test failures unnecessarily tedious (developers had to re-run the command manually to see why it failed).

## Approach

Capture combined stdout+stderr via `$()` and print it **only on failure**. On success the output remains exactly as before (clean PASS lines). On failure, developers immediately see what went wrong:

**Before:**
````
  FAIL: some-test (expected zero exit)
```

**After:**
```
  FAIL: some-test (expected zero exit, got status 2)
        output: Error: unrecognised argument '--typo'
```

Three helpers updated:
- `assert_zero_exit` — also improves failure message to include the actual exit status
- `assert_nonzero_exit` — shows output when command unexpectedly succeeds
- `assert_exit_status` — shows output when status doesn't match expectation

## Test status

All 407 existing bash tests pass unchanged:

```
for f in tests/test-*.sh; do bash "$f" 2>&1 | tail -1; done
# Results: 407 passed, 0 failed (across 16 test files)
````

shellcheck clean.

## Trade-offs

- Commands run inside `$()` instead of direct execution: combined stdout+stderr is captured rather than flowing to the terminal on success. Existing test output is unchanged (commands in these assertions don't produce significant stdout).
- Pure infrastructure change — no new test cases added, no test logic modified.

## Reproducibility

```bash
bash tests/test-helpers.sh        # library only, no self-tests
for f in tests/test-*.sh; do bash "$f"; done
```




> Generated by [Daily Test Improver](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/26167480128/agentic_workflow) · ● 3.1M · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, model: auto, id: 26167480128, workflow_id: daily-test-improver, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/26167480128 -->

<!-- gh-aw-workflow-id: daily-test-improver -->