### PR TITLE
[Test Improver] test: verify cmake flags and failure propagation in test-entrypoint.sh

### DIFF
--- a/tests/test-entrypoint.sh
+++ b/tests/test-entrypoint.sh
@@ -148,4 +148,79 @@ _LOG5=$(cat "$_CMAKE_LOG")
 assert_contains "relative SOURCE_DIR: cmake toolchain file is absolute" \
     "$_LOG5" "${_PARENT5}/${_SRC5_NAME}/arm-none-eabi-gcc.cmake"
 
+# ---------------------------------------------------------------------------
+# Group 6: cmake configure flags verification
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 6: cmake configure flags ==="
+
+_SRC6="${_TMPDIR}/src-flags"
+_BUILD6="${_TMPDIR}/build-flags"
+mkdir -p "$_SRC6"
+touch "$_SRC6/arm-none-eabi-gcc.cmake"
+
+true > "$_CMAKE_LOG"
+CMAKE_LOG="$_CMAKE_LOG" PATH="${_MOCK_BIN}:${PATH}" sh "$ENTRYPOINT" "$_SRC6" "$_BUILD6" >/dev/null 2>&1
+
+_LOG6=$(cat "$_CMAKE_LOG")
+
+assert_contains "configure: -G flag passed" \
+    "$_LOG6" "-G"
+assert_contains "configure: Unix Makefiles generator specified" \
+    "$_LOG6" "Unix Makefiles"
+assert_contains "configure: CMAKE_C_COMPILER set to arm-none-eabi-gcc" \
+    "$_LOG6" "-DCMAKE_C_COMPILER=arm-none-eabi-gcc"
+assert_contains "configure: CMAKE_CXX_COMPILER set to arm-none-eabi-g++" \
+    "$_LOG6" "-DCMAKE_CXX_COMPILER=arm-none-eabi-g++"
+assert_contains "configure: CMAKE_TOOLCHAIN_FILE flag passed" \
+    "$_LOG6" "-DCMAKE_TOOLCHAIN_FILE="
+assert_contains "configure: -S SOURCE_DIR passed" \
+    "$_LOG6" "-S"
+
+# ---------------------------------------------------------------------------
+# Group 7: cmake --build step flags
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 7: cmake build step flags ==="
+
+_SRC7="${_TMPDIR}/src-build-flags"
+_BUILD7="${_TMPDIR}/build-build-flags"
+mkdir -p "$_SRC7"
+touch "$_SRC7/arm-none-eabi-gcc.cmake"
+
+true > "$_CMAKE_LOG"
+CMAKE_LOG="$_CMAKE_LOG" PATH="${_MOCK_BIN}:${PATH}" sh "$ENTRYPOINT" "$_SRC7" "$_BUILD7" >/dev/null 2>&1
+
+_LOG7=$(cat "$_CMAKE_LOG")
+
+assert_contains "cmake --build: receives BUILD_DIR" \
+    "$_LOG7" "$_BUILD7"
+assert_matches "cmake --build: receives -j flag" \
+    "$_LOG7" "^-j[0-9]"
+
+# ---------------------------------------------------------------------------
+# Group 8: cmake failure propagation
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 8: cmake failure propagation ==="
+
+_FAIL_BIN="${_TMPDIR}/fail-bin"
+mkdir -p "$_FAIL_BIN"
+cat > "$_FAIL_BIN/cmake" <<'FAILEOF'
+#!/bin/sh
+exit 1
+FAILEOF
+chmod +x "$_FAIL_BIN/cmake"
+
+_SRC8="${_TMPDIR}/src-fail"
+mkdir -p "$_SRC8"
+touch "$_SRC8/arm-none-eabi-gcc.cmake"
+
+_fail_status=0
+CMAKE_LOG="/dev/null" PATH="${_FAIL_BIN}:${PATH}" sh "$ENTRYPOINT" "$_SRC8" "${_TMPDIR}/build-fail" >/dev/null 2>&1 || _fail_status=$?
+assert_ne "cmake configure fails: entrypoint exits non-zero" "0" "$_fail_status"
+
 print_test_results


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant.*

## Goal and rationale

`test-entrypoint.sh` covered error conditions (missing SOURCE_DIR, missing cmake file) and high-level happy-path behaviour (exit 0, correct BUILD_DIR), but did not verify the exact cmake arguments that `entrypoint.sh` passes to cmake. Three missing groups:

1. **Required configure flags** — if `-DCMAKE_C_COMPILER`, `-DCMAKE_CXX_COMPILER`, `-DCMAKE_TOOLCHAIN_FILE=`, `-G "Unix Makefiles"`, or `-S` were accidentally dropped from `entrypoint.sh`, the existing tests would not catch it.
2. **Build step flags** — the `cmake --build` invocation's parallelism flag (`-j$(nproc)`) was unverified.
3. **Failure propagation** — `set -e` is expected to propagate a non-zero cmake exit, but this wasn't confirmed by any test.

## Approach

Three new groups added to `tests/test-entrypoint.sh`:

| Group | Scenario | Assertions |
|-------|----------|------------|
| 6 | cmake configure flags | `-G`, `Unix Makefiles`, `-DCMAKE_C_COMPILER`, `-DCMAKE_CXX_COMPILER`, `-DCMAKE_TOOLCHAIN_FILE=`, `-S` (6 cases) |
| 7 | cmake `--build` flags | BUILD_DIR and `-j<N>` present (2 cases) |
| 8 | cmake failure propagation | failing cmake → non-zero entrypoint exit (1 case) |

The existing mock cmake writes all arguments one-per-line to `$CMAKE_LOG`; Groups 6–7 query that log. Group 8 adds a separate fail-mock that always exits 1.

## Coverage impact

| Metric | Before | After |
|--------|--------|-------|
| `test-entrypoint.sh` tests | 13 | **22** (+9) |
| Total bash test count | 407 | **416** (+9) |

## Test status

All 416 bash tests pass:

```
tests/test-entrypoint.sh: Results: 22 passed, 0 failed
(all other 15 test files: unchanged, all passing)
```

shellcheck clean (matches CI invocation with multiple files as arguments).

## Reproducibility

```bash
bash tests/test-entrypoint.sh
for f in tests/test-*.sh; do bash "$f" 2>&1 | tail -1; done
```




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 1 item</summary>
>
> The following item were blocked because they don't meet the GitHub integrity level.
>
> - [#745](https://github.com/grahame-org/gnu-tools-for-stm32/pull/745) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Test Improver](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/26291178366/agentic_workflow) · ● 5.3M · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, model: auto, id: 26291178366, workflow_id: daily-test-improver, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/26291178366 -->

<!-- gh-aw-workflow-id: daily-test-improver -->