### PR TITLE
[Test Improver] test: add path/file/dir existence assertion helpers to test-helpers.sh

### DIFF
--- a/tests/test-build-common.sh
+++ b/tests/test-build-common.sh
@@ -296,22 +296,22 @@ assert_eq "copy_dir_clean copies regular file" \
     "keep me" "$(cat "$_CDC_TMPDIR/dst/normal.txt")"
 assert_eq "copy_dir_clean copies nested file in regular subdir" \
     "keep me too" "$(cat "$_CDC_TMPDIR/dst/normal_subdir/child.txt")"
-assert_eq "copy_dir_clean excludes .git directory" \
-    "" "$([ -e "$_CDC_TMPDIR/dst/.git" ] && echo "exists" || true)"
-assert_eq "copy_dir_clean excludes CVS directory" \
-    "" "$([ -e "$_CDC_TMPDIR/dst/CVS" ] && echo "exists" || true)"
-assert_eq "copy_dir_clean excludes .svn directory" \
-    "" "$([ -e "$_CDC_TMPDIR/dst/.svn" ] && echo "exists" || true)"
-assert_eq "copy_dir_clean excludes .pc directory" \
-    "" "$([ -e "$_CDC_TMPDIR/dst/.pc" ] && echo "exists" || true)"
-assert_eq "copy_dir_clean excludes *~ backup files" \
-    "" "$([ -e "$_CDC_TMPDIR/dst/file.txt~" ] && echo "exists" || true)"
-assert_eq "copy_dir_clean excludes *.orig files" \
-    "" "$([ -e "$_CDC_TMPDIR/dst/patch.orig" ] && echo "exists" || true)"
-assert_eq "copy_dir_clean excludes *.rej files" \
-    "" "$([ -e "$_CDC_TMPDIR/dst/patch.rej" ] && echo "exists" || true)"
-assert_eq "copy_dir_clean excludes .#* emacs lock files" \
-    "" "$([ -e "$_CDC_TMPDIR/dst/.#lockfile" ] && echo "exists" || true)"
+assert_path_not_exists "copy_dir_clean excludes .git directory" \
+    "$_CDC_TMPDIR/dst/.git"
+assert_path_not_exists "copy_dir_clean excludes CVS directory" \
+    "$_CDC_TMPDIR/dst/CVS"
+assert_path_not_exists "copy_dir_clean excludes .svn directory" \
+    "$_CDC_TMPDIR/dst/.svn"
+assert_path_not_exists "copy_dir_clean excludes .pc directory" \
+    "$_CDC_TMPDIR/dst/.pc"
+assert_path_not_exists "copy_dir_clean excludes *~ backup files" \
+    "$_CDC_TMPDIR/dst/file.txt~"
+assert_path_not_exists "copy_dir_clean excludes *.orig files" \
+    "$_CDC_TMPDIR/dst/patch.orig"
+assert_path_not_exists "copy_dir_clean excludes *.rej files" \
+    "$_CDC_TMPDIR/dst/patch.rej"
+assert_path_not_exists "copy_dir_clean excludes .#* emacs lock files" \
+    "$_CDC_TMPDIR/dst/.#lockfile"
 
 rm -rf "$_CDC_TMPDIR"
 
@@ -439,28 +439,28 @@ copy_multi_libs \
     target_gcc="${_CML_TMPDIR}/mock-gcc"
 
 # --- root multilib: renamed library files ---
-assert_eq "copy_multi_libs root: libstdc++_nano.a created" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/libstdc++_nano.a" ] && echo yes || echo no)"
-assert_eq "copy_multi_libs root: libsupc++_nano.a created" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/libsupc++_nano.a" ] && echo yes || echo no)"
-assert_eq "copy_multi_libs root: libc_nano.a created" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/libc_nano.a" ] && echo yes || echo no)"
-assert_eq "copy_multi_libs root: libg_nano.a created" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/libg_nano.a" ] && echo yes || echo no)"
-assert_eq "copy_multi_libs root: librdimon_nano.a created" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/librdimon_nano.a" ] && echo yes || echo no)"
-assert_eq "copy_multi_libs root: librdimon-v2m_nano.a created" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/librdimon-v2m_nano.a" ] && echo yes || echo no)"
+assert_file_exists "copy_multi_libs root: libstdc++_nano.a created" \
+    "${_CML_TMPDIR}/dst/libstdc++_nano.a"
+assert_file_exists "copy_multi_libs root: libsupc++_nano.a created" \
+    "${_CML_TMPDIR}/dst/libsupc++_nano.a"
+assert_file_exists "copy_multi_libs root: libc_nano.a created" \
+    "${_CML_TMPDIR}/dst/libc_nano.a"
+assert_file_exists "copy_multi_libs root: libg_nano.a created" \
+    "${_CML_TMPDIR}/dst/libg_nano.a"
+assert_file_exists "copy_multi_libs root: librdimon_nano.a created" \
+    "${_CML_TMPDIR}/dst/librdimon_nano.a"
+assert_file_exists "copy_multi_libs root: librdimon-v2m_nano.a created" \
+    "${_CML_TMPDIR}/dst/librdimon-v2m_nano.a"
 
 # --- root multilib: spec files and crt0 ---
-assert_eq "copy_multi_libs root: nano.specs copied" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/nano.specs" ] && echo yes || echo no)"
-assert_eq "copy_multi_libs root: rdimon.specs copied" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/rdimon.specs" ] && echo yes || echo no)"
-assert_eq "copy_multi_libs root: nosys.specs copied" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/nosys.specs" ] && echo yes || echo no)"
-assert_eq "copy_multi_libs root: crt0.o copied" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/crt0.o" ] && echo yes || echo no)"
+assert_file_exists "copy_multi_libs root: nano.specs copied" \
+    "${_CML_TMPDIR}/dst/nano.specs"
+assert_file_exists "copy_multi_libs root: rdimon.specs copied" \
+    "${_CML_TMPDIR}/dst/rdimon.specs"
+assert_file_exists "copy_multi_libs root: nosys.specs copied" \
+    "${_CML_TMPDIR}/dst/nosys.specs"
+assert_file_exists "copy_multi_libs root: crt0.o copied" \
+    "${_CML_TMPDIR}/dst/crt0.o"
 
 # --- root multilib: source content is preserved ---
 assert_eq "copy_multi_libs root: libstdc++_nano.a preserves content" \
@@ -468,14 +468,14 @@ assert_eq "copy_multi_libs root: libstdc++_nano.a preserves content" \
 
 # --- nested multilib ---
 _CML_NESTED="thumb/v8-m.main/fp"
-assert_eq "copy_multi_libs nested: libstdc++_nano.a created" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/${_CML_NESTED}/libstdc++_nano.a" ] && echo yes || echo no)"
-assert_eq "copy_multi_libs nested: libc_nano.a created" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/${_CML_NESTED}/libc_nano.a" ] && echo yes || echo no)"
-assert_eq "copy_multi_libs nested: nano.specs copied" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/${_CML_NESTED}/nano.specs" ] && echo yes || echo no)"
-assert_eq "copy_multi_libs nested: crt0.o copied" \
-    "yes" "$([ -f "${_CML_TMPDIR}/dst/${_CML_NESTED}/crt0.o" ] && echo yes || echo no)"
+assert_file_exists "copy_multi_libs nested: libstdc++_nano.a created" \
+    "${_CML_TMPDIR}/dst/${_CML_NESTED}/libstdc++_nano.a"
+assert_file_exists "copy_multi_libs nested: libc_nano.a created" \
+    "${_CML_TMPDIR}/dst/${_CML_NESTED}/libc_nano.a"
+assert_file_exists "copy_multi_libs nested: nano.specs copied" \
+    "${_CML_TMPDIR}/dst/${_CML_NESTED}/nano.specs"
+assert_file_exists "copy_multi_libs nested: crt0.o copied" \
+    "${_CML_TMPDIR}/dst/${_CML_NESTED}/crt0.o"
 
 # --- empty print-multi-lib: function is a no-op (exits 0) ---
 cat > "${_CML_TMPDIR}/empty-gcc" << 'EMPTY_GCC_EOF'

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -167,6 +167,66 @@ assert_unset() {
     fi
 }
 
+assert_file_exists() {
+    local desc="$1" path="$2"
+    if [ -f "$path" ]; then
+        _PASS=$((_PASS + 1))
+        echo "  PASS: $desc"
+    else
+        _FAIL=$((_FAIL + 1))
+        echo "  FAIL: $desc"
+        echo "        expected file to exist: [$path]"
+    fi
+}
+
+assert_file_not_exists() {
+    local desc="$1" path="$2"
+    if [ ! -f "$path" ]; then
+        _PASS=$((_PASS + 1))
+        echo "  PASS: $desc"
+    else
+        _FAIL=$((_FAIL + 1))
+        echo "  FAIL: $desc"
+        echo "        expected file NOT to exist: [$path]"
+    fi
+}
+
+assert_path_not_exists() {
+    local desc="$1" path="$2"
+    if [ ! -e "$path" ]; then
+        _PASS=$((_PASS + 1))
+        echo "  PASS: $desc"
+    else
+        _FAIL=$((_FAIL + 1))
+        echo "  FAIL: $desc"
+        echo "        expected path NOT to exist: [$path]"
+    fi
+}
+
+assert_dir_exists() {
+    local desc="$1" path="$2"
+    if [ -d "$path" ]; then
+        _PASS=$((_PASS + 1))
+        echo "  PASS: $desc"
+    else
+        _FAIL=$((_FAIL + 1))
+        echo "  FAIL: $desc"
+        echo "        expected directory to exist: [$path]"
+    fi
+}
+
+assert_dir_not_exists() {
+    local desc="$1" path="$2"
+    if [ ! -d "$path" ]; then
+        _PASS=$((_PASS + 1))
+        echo "  PASS: $desc"
+    else
+        _FAIL=$((_FAIL + 1))
+        echo "  FAIL: $desc"
+        echo "        expected directory NOT to exist: [$path]"
+    fi
+}
+
 print_test_results() {
     echo ""
     echo "Results: $_PASS passed, $_FAIL failed"

--- a/tests/test-pre-cache-clean.sh
+++ b/tests/test-pre-cache-clean.sh
@@ -163,18 +163,12 @@ echo "keep" > "$_ROOT5/bin/keep"
 
 bash "$SCRIPT" "$_ROOT5" >/dev/null 2>&1
 
-assert_eq "share/man removed" "absent" \
-    "$([ -d "$_ROOT5/share/man" ] && echo present || echo absent)"
-assert_eq "share/info removed" "absent" \
-    "$([ -d "$_ROOT5/share/info" ] && echo present || echo absent)"
-assert_eq "share/locale removed" "absent" \
-    "$([ -d "$_ROOT5/share/locale" ] && echo present || echo absent)"
-assert_eq "share/doc removed" "absent" \
-    "$([ -d "$_ROOT5/share/doc" ] && echo present || echo absent)"
-assert_eq "arm-none-eabi/share removed" "absent" \
-    "$([ -d "$_ROOT5/arm-none-eabi/share" ] && echo present || echo absent)"
-assert_eq "bin/keep not removed" "present" \
-    "$([ -f "$_ROOT5/bin/keep" ] && echo present || echo absent)"
+assert_dir_not_exists "share/man removed" "$_ROOT5/share/man"
+assert_dir_not_exists "share/info removed" "$_ROOT5/share/info"
+assert_dir_not_exists "share/locale removed" "$_ROOT5/share/locale"
+assert_dir_not_exists "share/doc removed" "$_ROOT5/share/doc"
+assert_dir_not_exists "arm-none-eabi/share removed" "$_ROOT5/arm-none-eabi/share"
+assert_file_exists "bin/keep not removed" "$_ROOT5/bin/keep"
 
 # ---------------------------------------------------------------------------
 # Test group 6: .la files are removed


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant.*

## Goal and rationale

`test-helpers.sh` had no helpers for checking whether files or directories exist. Tests were forced to write verbose inline subshell expressions like:

````bash
assert_eq "copy_multi_libs root: libstdc++_nano.a created" \
    "yes" "$([ -f "\$\{_CML_TMPDIR}/dst/libstdc++_nano.a" ] && echo yes || echo no)"

assert_eq "copy_dir_clean excludes .git directory" \
    "" "$([ -e "$_CDC_TMPDIR/dst/.git" ] && echo "exists" || true)"
```

These patterns are verbose, and on failure the message shows `expected: [yes]  actual: []` — the *path* is not included in the output, making diagnosis harder. The `A && B || C` form also triggered shellcheck SC2015 warnings.

## Approach

1. **Added 5 new helpers to `test-helpers.sh`**:
   - `assert_file_exists desc path` — `[ -f path ]`
   - `assert_file_not_exists desc path` — `[ ! -f path ]`
   - `assert_path_not_exists desc path` — `[ ! -e path ]` (works for files and directories)
   - `assert_dir_exists desc path` — `[ -d path ]`
   - `assert_dir_not_exists desc path` — `[ ! -d path ]`

   On failure each prints the path directly:
   ```
   FAIL: copy_multi_libs root: libstdc++_nano.a created
         expected file to exist: [/tmp/xxx/dst/libstdc++_nano.a]
   ```

2. **Refactored 28 verbose patterns** across two test files:
   - `test-build-common.sh`: 8 `assert_path_not_exists` (copy_dir_clean exclusions) + 14 `assert_file_exists` (copy_multi_libs outputs)
   - `test-pre-cache-clean.sh`: 5 `assert_dir_not_exists` + 1 `assert_file_exists`

   This also removes 8 pre-existing **SC2015** shellcheck warnings on the `A && B || C` patterns.

## Coverage impact

No change in test count (407 total on main; same after refactoring). Pure readability and diagnostics improvement.

## Trade-offs

- Small maintenance surface added (5 helpers), each ~6 lines
- No new test dependencies

## Test status

All 407 bash tests pass locally:

```
test-build-cache-budget-check.sh  18 passed, 0 failed
test-build-common.sh              77 passed, 0 failed
test-build-prerequisites.sh       16 passed, 0 failed
test-build-stage-scripts.sh       23 passed, 0 failed
test-build-toolchain.sh           18 passed, 0 failed
test-build-toolchain-args.sh      87 passed, 0 failed
test-build-toolchain-cache-keys.sh 19 passed, 0 failed
test-compute-toolchain-src-hash.sh 13 passed, 0 failed
test-measure-cache-compressed-size.sh 8 passed, 0 failed
test-merge-gcc-final.sh           26 passed, 0 failed
test-entrypoint.sh                13 passed, 0 failed
test-compare-test-project-artifacts.sh 29 passed, 0 failed
test-pre-cache-clean.sh           35 passed, 0 failed
test-strip-binary.sh              13 passed, 0 failed
test-build-gcc-size-libstdcxx.sh  12 passed, 0 failed
````

Shellcheck: no new warnings introduced; 8 pre-existing SC2015 warnings removed.




> Generated by [Daily Test Improver](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/26360924759/agentic_workflow) · ● 4M · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, model: auto, id: 26360924759, workflow_id: daily-test-improver, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/26360924759 -->

<!-- gh-aw-workflow-id: daily-test-improver -->