### PR TITLE
[Test Improver] test: add clean_env unit tests to test-build-common.sh

### DIFF
--- a/tests/test-build-common.sh
+++ b/tests/test-build-common.sh
@@ -495,6 +495,88 @@ rm -rf "${_CML_NOOP_TMPDIR}"
 rm -rf "$_CML_TMPDIR"
 
 # ---------------------------------------------------------------------------
+# Test group 15: clean_env
+#
+# clean_env() scrubs exported uppercase variables from the shell environment,
+# keeping a fixed whitelist (PATH, HOME, SHELL, etc.).  Each test runs in a
+# subshell so the parent test process environment is not disturbed.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Group 15: clean_env ==="
+
+# Non-whitelisted uppercase variable is removed.
+_ce1=$(bash -c \
+    '. "$1/build-common.sh"
+     export TEST_CLEAN_ENV_XYZZY=sentinel
+     clean_env
+     echo "${TEST_CLEAN_ENV_XYZZY:-cleared}"' \
+    _ "$REPO_ROOT")
+assert_eq "clean_env removes non-whitelisted uppercase variable" "cleared" "$_ce1"
+
+# PATH is preserved (explicitly whitelisted).
+_ce2=$(bash -c \
+    '. "$1/build-common.sh"
+     clean_env
+     echo "${PATH:+present}"' \
+    _ "$REPO_ROOT")
+assert_eq "clean_env preserves PATH (whitelisted)" "present" "$_ce2"
+
+# HOME is preserved (explicitly whitelisted).
+_ce3=$(bash -c \
+    '. "$1/build-common.sh"
+     clean_env
+     echo "${HOME:+present}"' \
+    _ "$REPO_ROOT")
+assert_eq "clean_env preserves HOME (whitelisted)" "present" "$_ce3"
+
+# SHELL is preserved (explicitly whitelisted).
+_ce4=$(bash -c \
+    '. "$1/build-common.sh"
+     clean_env
+     echo "${SHELL:+present}"' \
+    _ "$REPO_ROOT")
+assert_eq "clean_env preserves SHELL (whitelisted)" "present" "$_ce4"
+
+# An exported all-lowercase variable is not touched (only names with uppercase
+# characters reach the unset loop).
+_ce5=$(bash -c \
+    '. "$1/build-common.sh"
+     export testcleanenvlower=sentinel
+     clean_env
+     echo "${testcleanenvlower:-gone}"' \
+    _ "$REPO_ROOT")
+assert_eq "clean_env leaves exported lowercase variable untouched" "sentinel" "$_ce5"
+
+# WORKSPACE is preserved when set (explicitly whitelisted).
+_ce6=$(bash -c \
+    '. "$1/build-common.sh"
+     export WORKSPACE=/some/path
+     clean_env
+     echo "${WORKSPACE:-cleared}"' \
+    _ "$REPO_ROOT")
+assert_eq "clean_env preserves WORKSPACE (whitelisted)" "/some/path" "$_ce6"
+
+# SRC_VERSION is preserved when set (explicitly whitelisted).
+_ce7=$(bash -c \
+    '. "$1/build-common.sh"
+     export SRC_VERSION=1.2.3
+     clean_env
+     echo "${SRC_VERSION:-cleared}"' \
+    _ "$REPO_ROOT")
+assert_eq "clean_env preserves SRC_VERSION (whitelisted)" "1.2.3" "$_ce7"
+
+# Multiple non-whitelisted uppercase variables are all removed in a single call.
+_ce8=$(bash -c \
+    '. "$1/build-common.sh"
+     export CLEAN_ENV_ALPHA=a CLEAN_ENV_BETA=b
+     clean_env
+     echo "${CLEAN_ENV_ALPHA:-cleared}:${CLEAN_ENV_BETA:-cleared}"' \
+    _ "$REPO_ROOT")
+assert_eq "clean_env removes multiple non-whitelisted variables in one call" \
+    "cleared:cleared" "$_ce8"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant.*

## Goal and rationale

`clean_env()` in `build-common.sh` scrubs the shell environment before a build run, keeping a fixed whitelist of essential variables (`PATH`, `HOME`, `SHELL`, `WORKSPACE`, `SRC_VERSION`, etc.) and unsetting everything else. Despite containing a non-trivial pipeline (`export | grep | sed | cut`) and an explicit whitelist, it had **no unit tests**.

A broken whitelist entry (e.g. a typo or missing variable) would silently strip something a downstream build stage needs — or fail to strip something it shouldn't keep. Tests catch these regressions.

## Approach

Added **Group 15** (8 tests) to `tests/test-build-common.sh`. Each test runs in a subshell to avoid disturbing the parent test process's environment:

| Test | What it checks |
|------|---------------|
| Non-whitelisted uppercase variable removed | Core cleanup behaviour |
| `PATH` preserved | Whitelisted — must survive |
| `HOME` preserved | Whitelisted — must survive |
| `SHELL` preserved | Whitelisted — must survive |
| `WORKSPACE` preserved when set | Build-specific whitelist entry |
| `SRC_VERSION` preserved when set | Build-specific whitelist entry |
| Exported lowercase variable untouched | Only uppercase names enter the unset loop |
| Multiple non-whitelisted variables all cleared | Bulk cleanup correctness |

## Coverage impact

No coverage tooling configured. Test count impact:

| Suite | Before | After | Delta |
|-------|--------|-------|-------|
| Bash unit tests | 407 | 415 | +8 |

## Trade-offs

- Each test spawns a subshell (`bash -c '...'`) to isolate environment changes — adds ~0.1 s total, acceptable.
- The whitelist is tested by name (`PATH`, `HOME`, etc.) which means tests will flag if an entry is accidentally removed from the whitelist.

## Test status

```
=== Group 15: clean_env ===
  PASS: clean_env removes non-whitelisted uppercase variable
  PASS: clean_env preserves PATH (whitelisted)
  PASS: clean_env preserves HOME (whitelisted)
  PASS: clean_env preserves SHELL (whitelisted)
  PASS: clean_env leaves exported lowercase variable untouched
  PASS: clean_env preserves WORKSPACE (whitelisted)
  PASS: clean_env preserves SRC_VERSION (whitelisted)
  PASS: clean_env removes multiple non-whitelisted variables in one call

Results: 85 passed, 0 failed
```

Full suite: **415 passed, 0 failed** (407 baseline + 8 new). No new shellcheck warnings.

## Reproducibility

```bash
bash tests/test-build-common.sh
```




> Generated by [Daily Test Improver](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/26405076308/agentic_workflow) · ● 3.1M · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, model: auto, id: 26405076308, workflow_id: daily-test-improver, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/26405076308 -->

<!-- gh-aw-workflow-id: daily-test-improver -->