### PR TITLE
[Test Improver] test: add assert_empty and assert_nonempty helpers, refactor 20 patterns

### DIFF
--- a/tests/test-build-cache-budget-check.sh
+++ b/tests/test-build-cache-budget-check.sh
@@ -141,7 +141,7 @@ assert_zero_exit "GITHUB_STEP_SUMMARY file is created when variable is set" \
     test -f "${_SUMMARY_FILE}"
 
 summary_content=$(cat "${_SUMMARY_FILE}")
-assert_ne "GITHUB_STEP_SUMMARY is non-empty" "" "${summary_content}"
+assert_nonempty "GITHUB_STEP_SUMMARY is non-empty" "${summary_content}"
 assert_contains "GITHUB_STEP_SUMMARY contains table heading" \
     "${summary_content}" "Cache Budget Validation"
 assert_contains "GITHUB_STEP_SUMMARY mentions install-native" \

--- a/tests/test-build-stage-scripts.sh
+++ b/tests/test-build-stage-scripts.sh
@@ -113,7 +113,7 @@ assert_eq "CACHE_MISS=false → cache-hit=true" "true" \
     "$(run_set_cache_hit_output "false")"
 assert_eq "CACHE_MISS='' → cache-hit=true" "true" \
     "$(run_set_cache_hit_output "")"
-assert_eq "CACHE_MISS=true → cache-hit='' (empty)" "" \
+assert_empty "CACHE_MISS=true → cache-hit='' (empty)" \
     "$(run_set_cache_hit_output "true")"
 
 # ---------------------------------------------------------------------------
@@ -172,7 +172,7 @@ run_build_stage() {
 
 # build-time-seconds is written to GITHUB_OUTPUT.
 _bts=$(run_build_stage "")
-assert_ne "empty args: build-time-seconds written to GITHUB_OUTPUT" "" "$_bts"
+assert_nonempty "empty args: build-time-seconds written to GITHUB_OUTPUT" "$_bts"
 
 # build-time-seconds is an integer.
 case "$_bts" in
@@ -214,7 +214,7 @@ JOBS_LOG="$_JOBS_LOG" \
 GITHUB_OUTPUT="$_gh_out" \
 bash "$_RUN_SCRIPT"
 _jobs_val=$(cat "$_JOBS_LOG")
-assert_ne "JOBS exported to build script and non-empty" "" "$_jobs_val"
+assert_nonempty "JOBS exported to build script and non-empty" "$_jobs_val"
 case "$_jobs_val" in
     ''|*[!0-9]*) assert_eq "JOBS exported to build script is numeric" "numeric" "non-numeric" ;;
     *)           assert_eq "JOBS exported to build script is numeric" "numeric" "numeric" ;;

--- a/tests/test-build-toolchain-args.sh
+++ b/tests/test-build-toolchain-args.sh
@@ -28,7 +28,7 @@ assert_eq "--skip_steps=manual,strip produces space-separated value" \
     "manual strip" "$skip_steps"
 
 parse_toolchain_args --skip_steps=
-assert_eq "--skip_steps= (empty) produces empty variable" "" "$skip_steps"
+assert_empty "--skip_steps= (empty) produces empty variable" "$skip_steps"
 
 parse_toolchain_args --skip_steps=manual,package_bins,strip
 assert_eq "--skip_steps=manual sets skip_manual=yes" "yes" "$skip_manual"
@@ -74,7 +74,7 @@ assert_eq "--skip_stages=binutils,gcc-first produces space-separated value" \
     "binutils gcc-first" "$skip_stages"
 
 parse_toolchain_args --skip_stages=
-assert_eq "--skip_stages= (empty) produces empty variable" "" "$skip_stages"
+assert_empty "--skip_stages= (empty) produces empty variable" "$skip_stages"
 
 parse_toolchain_args --skip_stages=newlib
 assert_eq "--skip_stages=newlib sets skip_stages=newlib" "newlib" "$skip_stages"
@@ -121,9 +121,9 @@ echo ""
 echo "=== Group 4: defaults when no flags given ==="
 
 parse_toolchain_args
-assert_eq "default skip_steps is empty"       ""    "$skip_steps"
-assert_eq "default skip_stages is empty"      ""    "$skip_stages"
-assert_eq "default build_type is empty"       ""    "$build_type"
+assert_empty "default skip_steps is empty"       "$skip_steps"
+assert_empty "default skip_stages is empty"      "$skip_stages"
+assert_empty "default build_type is empty"       "$build_type"
 assert_eq "default is_native_build=yes"       "yes" "$is_native_build"
 assert_eq "default is_ppa_release=no"         "no"  "$is_ppa_release"
 assert_eq "default is_debug_build=no"         "no"  "$is_debug_build"
@@ -211,9 +211,9 @@ parse_toolchain_args --build_type=ppa,debug \
     --skip_stages=binutils --with-multilib-list=rmprofile
 # Now call again with no args — everything should revert to defaults
 parse_toolchain_args
-assert_eq "reset: skip_steps is empty"              "" "$skip_steps"
-assert_eq "reset: skip_stages is empty"             "" "$skip_stages"
-assert_eq "reset: build_type is empty"              "" "$build_type"
+assert_empty "reset: skip_steps is empty"              "$skip_steps"
+assert_empty "reset: skip_stages is empty"             "$skip_stages"
+assert_empty "reset: build_type is empty"              "$build_type"
 assert_eq "reset: is_native_build=yes"              "yes" "$is_native_build"
 assert_eq "reset: is_ppa_release=no"                "no" "$is_ppa_release"
 assert_eq "reset: is_debug_build=no"                "no" "$is_debug_build"

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -167,6 +167,29 @@ assert_unset() {
     fi
 }
 
+assert_empty() {
+    local desc="$1" actual="$2"
+    if [ -z "$actual" ]; then
+        _PASS=$((_PASS + 1))
+        echo "  PASS: $desc"
+    else
+        _FAIL=$((_FAIL + 1))
+        echo "  FAIL: $desc"
+        echo "        expected empty, got: [$actual]"
+    fi
+}
+
+assert_nonempty() {
+    local desc="$1" actual="$2"
+    if [ -n "$actual" ]; then
+        _PASS=$((_PASS + 1))
+        echo "  PASS: $desc"
+    else
+        _FAIL=$((_FAIL + 1))
+        echo "  FAIL: $desc (expected non-empty, was empty)"
+    fi
+}
+
 print_test_results() {
     echo ""
     echo "Results: $_PASS passed, $_FAIL failed"

--- a/tests/test-measure-cache-compressed-size.sh
+++ b/tests/test-measure-cache-compressed-size.sh
@@ -81,7 +81,7 @@ PATH="$_EMPTYBIN" "${BASH}" "$SCRIPT" "$_DIR4" >/dev/null 2>/dev/null || _exit4=
 assert_eq "tools absent: exits 0" "0" "$_exit4"
 
 _stderr4=$(PATH="$_EMPTYBIN" "${BASH}" "$SCRIPT" "$_DIR4" 2>&1 1>/dev/null)
-assert_ne "tools absent: warning printed to stderr" "" "$_stderr4"
+assert_nonempty "tools absent: warning printed to stderr" "$_stderr4"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/test-pre-cache-clean.sh
+++ b/tests/test-pre-cache-clean.sh
@@ -63,7 +63,7 @@ assert_zero_exit "non-existent dir: exits 0" bash "$SCRIPT" "$_NOEXIST"
 
 # Verify warning is printed to stderr
 _warn_out=$( bash "$SCRIPT" "$_NOEXIST" 2>&1 1>/dev/null )
-assert_ne "non-existent dir: warning printed" "" "$_warn_out"
+assert_nonempty "non-existent dir: warning printed" "$_warn_out"
 
 # ---------------------------------------------------------------------------
 # Test group 3: ELF binaries in bin/ are stripped

--- a/tests/test-strip-binary.sh
+++ b/tests/test-strip-binary.sh
@@ -65,17 +65,17 @@ echo "=== Group 1: Wrong argument counts ==="
 reset_strip_log
 STRIP_LOG="$_STRIP_LOG" strip_binary 2>/dev/null; _ret=$?
 assert_eq "0 args: returns 0" "0" "$_ret"
-assert_eq "0 args: strip not called" "" "$([ -f "$_STRIP_LOG" ] && echo called || true)"
+assert_empty "0 args: strip not called" "$([ -f "$_STRIP_LOG" ] && echo called || true)"
 
 reset_strip_log
 STRIP_LOG="$_STRIP_LOG" strip_binary "$_MOCK_STRIP" 2>/dev/null; _ret=$?
 assert_eq "1 arg: returns 0" "0" "$_ret"
-assert_eq "1 arg: strip not called" "" "$([ -f "$_STRIP_LOG" ] && echo called || true)"
+assert_empty "1 arg: strip not called" "$([ -f "$_STRIP_LOG" ] && echo called || true)"
 
 reset_strip_log
 STRIP_LOG="$_STRIP_LOG" strip_binary "$_MOCK_STRIP" /some/file extra_arg 2>/dev/null; _ret=$?
 assert_eq "3 args: returns 0" "0" "$_ret"
-assert_eq "3 args: strip not called" "" "$([ -f "$_STRIP_LOG" ] && echo called || true)"
+assert_empty "3 args: strip not called" "$([ -f "$_STRIP_LOG" ] && echo called || true)"
 
 # ---------------------------------------------------------------------------
 # Test group 2: Non-binary files → strip not called
@@ -89,14 +89,14 @@ echo "hello world" > "$_TEXT_FILE"
 
 reset_strip_log
 STRIP_LOG="$_STRIP_LOG" strip_binary "$_MOCK_STRIP" "$_TEXT_FILE"
-assert_eq "plain text file: strip not called" "" "$([ -f "$_STRIP_LOG" ] && echo called || true)"
+assert_empty "plain text file: strip not called" "$([ -f "$_STRIP_LOG" ] && echo called || true)"
 
 _EMPTY_FILE="$_SB_TMPDIR/empty"
 : > "$_EMPTY_FILE"
 
 reset_strip_log
 STRIP_LOG="$_STRIP_LOG" strip_binary "$_MOCK_STRIP" "$_EMPTY_FILE"
-assert_eq "empty file: strip not called" "" "$([ -f "$_STRIP_LOG" ] && echo called || true)"
+assert_empty "empty file: strip not called" "$([ -f "$_STRIP_LOG" ] && echo called || true)"
 
 # ---------------------------------------------------------------------------
 # Test group 3: ELF binary → strip is called with correct path
@@ -126,7 +126,7 @@ _NOEXIST="$_SB_TMPDIR/no_such_file"
 
 reset_strip_log
 STRIP_LOG="$_STRIP_LOG" strip_binary "$_MOCK_STRIP" "$_NOEXIST" 2>/dev/null
-assert_eq "non-existent file: strip not called" "" "$([ -f "$_STRIP_LOG" ] && echo called || true)"
+assert_empty "non-existent file: strip not called" "$([ -f "$_STRIP_LOG" ] && echo called || true)"
 
 # ---------------------------------------------------------------------------
 # Test group 5: Strip command exits non-zero → silently ignored (|| true)


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant.*

## Goal and rationale

`assert_eq "desc" "" "$var"` and `assert_ne "desc" "" "$var"` are used in 20 places across 6 test files to check whether a variable is empty or non-empty. These patterns work but obscure intent — a reader must parse the argument order to understand what's being tested, and failure messages don't show what was actually found.

`assert_empty` and `assert_nonempty` communicate intent immediately and produce better failure messages:
- `assert_empty` shows the unexpected value: `expected empty, got: [foo]`
- `assert_nonempty` says: `expected non-empty, was empty`

## Approach

1. Added `assert_empty(desc, actual)` and `assert_nonempty(desc, actual)` to `tests/test-helpers.sh`
2. Replaced all 20 existing patterns across 6 test files:
   - `assert_eq "desc" "" "$var"` → `assert_empty "desc" "$var"` (15 places)
   - `assert_ne "desc" "" "$var"` → `assert_nonempty "desc" "$var"` (5 places)

Files changed: `test-helpers.sh`, `test-build-toolchain-args.sh` (8), `test-strip-binary.sh` (6), `test-build-stage-scripts.sh` (3), `test-build-cache-budget-check.sh` (1), `test-measure-cache-compressed-size.sh` (1), `test-pre-cache-clean.sh` (1).

## Coverage impact

Test counts are unchanged — all 20 are pure refactors of existing assertions (same logic, clearer expression).

| Suite | Before | After |
|-------|--------|-------|
| All bash tests | 407 passing | 407 passing |

## Trade-offs

- Two new helpers add minimal maintenance surface
- Refactors only — no behaviour change, no risk

## Test Status

All bash tests pass. `shellcheck --severity=info` clean on CI-listed modified files (`test-helpers.sh`, `test-build-stage-scripts.sh`, `test-measure-cache-compressed-size.sh`).

```
bash tests/test-build-toolchain-args.sh  → 87 passed, 0 failed
bash tests/test-strip-binary.sh          → 13 passed, 0 failed
bash tests/test-build-stage-scripts.sh   → 23 passed, 0 failed
bash tests/test-build-cache-budget-check.sh → 18 passed, 0 failed
bash tests/test-measure-cache-compressed-size.sh → 8 passed, 0 failed
bash tests/test-pre-cache-clean.sh       → 35 passed, 0 failed
```




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 4 items</summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [https://github.com/grahame-org/gnu-tools-for-stm32/commit/f7f8ba34fbe41e79eb1d05aa88208d10e9fafe35](https://github.com/grahame-org/gnu-tools-for-stm32/commit/f7f8ba34fbe41e79eb1d05aa88208d10e9fafe35) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/grahame-org/gnu-tools-for-stm32/commit/d66e89b17a7665d762c57896fa9f67fc8ac55e54](https://github.com/grahame-org/gnu-tools-for-stm32/commit/d66e89b17a7665d762c57896fa9f67fc8ac55e54) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/grahame-org/gnu-tools-for-stm32/commit/58df3230f5dbdb5ff1e21d51dcdb0c569b6a6be3](https://github.com/grahame-org/gnu-tools-for-stm32/commit/58df3230f5dbdb5ff1e21d51dcdb0c569b6a6be3) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/grahame-org/gnu-tools-for-stm32/commit/7c071b23645ff704081279c9fcc66b3dba912e15](https://github.com/grahame-org/gnu-tools-for-stm32/commit/7c071b23645ff704081279c9fcc66b3dba912e15) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Test Improver](https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/26582007298/agentic_workflow) · ● 3.7M · [◷](https://github.com/search?q=repo%3Agrahame-org%2Fgnu-tools-for-stm32+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, model: auto, id: 26582007298, workflow_id: daily-test-improver, run: https://github.com/grahame-org/gnu-tools-for-stm32/actions/runs/26582007298 -->

<!-- gh-aw-workflow-id: daily-test-improver -->